### PR TITLE
Refactoring to allow multiple payload types

### DIFF
--- a/src/File.ts
+++ b/src/File.ts
@@ -1,0 +1,11 @@
+class File {
+  readonly filepath: string
+  readonly data: string
+
+  constructor(filepath: string, data: string) {
+    this.filepath = filepath
+    this.data = data
+  }
+}
+
+export default File

--- a/src/__test__/Request.test.ts
+++ b/src/__test__/Request.test.ts
@@ -1,8 +1,9 @@
-import request, { send, isRetryable } from '../Request'
+import request, { PayloadType, send, isRetryable } from '../Request'
 import { UploadErrorCode } from '../UploadError'
 import http from 'http'
 import { AddressInfo } from 'net'
 import multiparty from 'multiparty'
+import File from '../File'
 
 let server: http.Server
 afterEach(() => server?.close())
@@ -38,10 +39,11 @@ test('request: send() successful upload', async () => {
   const port = (server.address() as AddressInfo).port
 
   await send(`http://localhost:${port}`, {
+    type: PayloadType.Browser,
     apiKey: '123',
     minifiedUrl: 'http://example.url',
-    sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
-    minifiedFile: { filepath: 'dist/app.js', data: 'console.log("hello")' }
+    sourceMap: new File('dist/app.js.map', '{}'),
+    minifiedFile: new File('dist/app.js', 'console.log("hello")')
   }, {})
 
   expect(received.length).toBe(1)
@@ -78,10 +80,11 @@ test('request: send() successful upload (with overwrite, appVersion)', async () 
   const port = (server.address() as AddressInfo).port
 
   await send(`http://localhost:${port}`, {
+    type: PayloadType.Browser,
     apiKey: '123',
     appVersion: '1.2.3',
     minifiedUrl: 'http://example.url',
-    sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
+    sourceMap: new File('dist/app.js.map', '{}'),
     overwrite: true
   }, {})
 
@@ -111,10 +114,11 @@ test('request: send() unsuccessful upload (invalid, no retry)', async () => {
 
   try {
     await send(`http://localhost:${port}`, {
+      type: PayloadType.Browser,
       apiKey: '123',
       minifiedUrl: 'http://example.url',
-      sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
-      minifiedFile: { filepath: 'dist/app.js', data: 'console.log("hello")' }
+      sourceMap: new File('dist/app.js.map', '{}'),
+      minifiedFile: new File('dist/app.js', 'console.log("hello")')
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(false)
@@ -134,10 +138,11 @@ test('request: send() unsuccessful upload (invalid, empty file)', async () => {
 
   try {
     await send(`http://localhost:${port}`, {
+      type: PayloadType.Browser,
       apiKey: '123',
       minifiedUrl: 'http://example.url',
-      sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
-      minifiedFile: { filepath: 'dist/app.js', data: 'console.log("hello")' }
+      sourceMap: new File('dist/app.js.map', '{}'),
+      minifiedFile: new File('dist/app.js', 'console.log("hello")')
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(false)
@@ -157,10 +162,11 @@ test('request: send() unsuccessful upload (misc 40x code)', async () => {
 
   try {
     await send(`http://localhost:${port}`, {
+      type: PayloadType.Browser,
       apiKey: '123',
       minifiedUrl: 'http://example.url',
-      sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
-      minifiedFile: { filepath: 'dist/app.js', data: 'console.log("hello")' }
+      sourceMap: new File('dist/app.js.map', '{}'),
+      minifiedFile: new File('dist/app.js', 'console.log("hello")')
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(false)
@@ -180,10 +186,11 @@ test('request: send() unsuccessful upload (unauthed, no retry)', async () => {
 
   try {
     await send(`http://localhost:${port}`, {
+      type: PayloadType.Browser,
       apiKey: '123',
       minifiedUrl: 'http://example.url',
-      sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
-      minifiedFile: { filepath: 'dist/app.js', data: 'console.log("hello")' }
+      sourceMap: new File('dist/app.js.map', '{}'),
+      minifiedFile: new File('dist/app.js', 'console.log("hello")')
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(false)
@@ -203,10 +210,11 @@ test('request: send() unsuccessful upload (retryable status)', async () => {
 
   try {
     await send(`http://localhost:${port}`, {
+      type: PayloadType.Browser,
       apiKey: '123',
       minifiedUrl: 'http://example.url',
-      sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
-      minifiedFile: { filepath: 'dist/app.js', data: 'console.log("hello")' }
+      sourceMap: new File('dist/app.js.map', '{}'),
+      minifiedFile: new File('dist/app.js', 'console.log("hello")')
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(true)
@@ -226,10 +234,11 @@ test('request: send() unsuccessful upload (timeout)', async () => {
 
   try {
     await send(`http://localhost:${port}`, {
+      type: PayloadType.Browser,
       apiKey: '123',
       minifiedUrl: 'http://example.url',
-      sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
-      minifiedFile: { filepath: 'dist/app.js', data: 'console.log("hello")' }
+      sourceMap: new File('dist/app.js.map', '{}'),
+      minifiedFile: new File('dist/app.js', 'console.log("hello")')
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(true)
@@ -249,10 +258,11 @@ test('request: send() unsuccessful upload (duplicate)', async () => {
 
   try {
     await send(`http://localhost:${port}`, {
+      type: PayloadType.Browser,
       apiKey: '123',
       minifiedUrl: 'http://example.url',
-      sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
-      minifiedFile: { filepath: 'dist/app.js', data: 'console.log("hello")' }
+      sourceMap: new File('dist/app.js.map', '{}'),
+      minifiedFile: new File('dist/app.js', 'console.log("hello")')
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(false)
@@ -273,10 +283,11 @@ test('request: request() multiple attempts at retryable errors', async () => {
 
   try {
     await request(`http://localhost:${port}`, {
+      type: PayloadType.Browser,
       apiKey: '123',
       minifiedUrl: 'http://example.url',
-      sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
-      minifiedFile: { filepath: 'dist/app.js', data: 'console.log("hello")' }
+      sourceMap: new File('dist/app.js.map', '{}'),
+      minifiedFile: new File('dist/app.js', 'console.log("hello")')
     }, {})
   } catch (e) {
     expect(requestsReceived).toBe(5)
@@ -296,11 +307,30 @@ test('request: request() multiple attempts, eventually succeeds', async () => {
 
   const port = (server.address() as AddressInfo).port
   await request(`http://localhost:${port}`, {
+    type: PayloadType.Browser,
     apiKey: '123',
     minifiedUrl: 'http://example.url',
-    sourceMap: { filepath: 'dist/app.js.map', data: '{}' },
-    minifiedFile: { filepath: 'dist/app.js', data: 'console.log("hello")' }
+    sourceMap: new File('dist/app.js.map', '{}'),
+    minifiedFile: new File('dist/app.js', 'console.log("hello")')
   }, {})
 
   expect(requestsReceived).toBe(4)
+})
+
+test('request: request() throws when given a ReactNative payload', async () => {
+  expect(async () => {
+    await request(`http://localhost`, {
+      type: PayloadType.ReactNative,
+      apiKey: '123'
+    }, {})
+  }).rejects.toThrow()
+})
+
+test('request: request() throws when given a Node payload', async () => {
+  expect(async () => {
+    await request(`http://localhost`, {
+      type: PayloadType.Node,
+      apiKey: '123'
+    }, {})
+  }).rejects.toThrow()
 })

--- a/src/uploaders/FormatErrorLog.ts
+++ b/src/uploaders/FormatErrorLog.ts
@@ -1,0 +1,33 @@
+import { UploadErrorCode, UploadError } from '../UploadError'
+
+function formatErrorLog (e: UploadError): string {
+  let str = ''
+  switch (e.code) {
+    case UploadErrorCode.EMPTY_FILE:
+      str += 'The uploaded source map was empty.'
+      break
+    case UploadErrorCode.INVALID_API_KEY:
+      str += 'The provided API key was invalid.'
+      break
+    case UploadErrorCode.MISC_BAD_REQUEST:
+      str += 'The request was rejected by the server as invalid.'
+      str += `\n\n  responseText = ${e.responseText}`
+      break
+    case UploadErrorCode.DUPLICATE:
+      str += 'A source map matching the same criteria has already been uploaded. If you want to replace it, use the "overwrite" flag.'
+      break
+    case UploadErrorCode.SERVER_ERROR:
+      str += 'A server side error occurred while processing the upload.'
+      str += `\n\n  responseText = ${e.responseText}`
+      break
+    case UploadErrorCode.TIMEOUT:
+      str += 'The request timed out.'
+      break
+    default:
+      str += 'An unexpected error occured.'
+  }
+  str += `\n\n`
+  return str
+}
+
+export default formatErrorLog


### PR DESCRIPTION
## Goal

Request.ts needs some refactoring in order to support sending payloads for React Native and node

## Changeset

Each type of payload has a `type` property which is an enum with the type of payload. This lets us switch on the type and call a function to build the form data that can be specific to one type of payload

A new `File` type now exists to make the `filepath`/`data` pairs less repetitive

The `formatErrorLog` function was extracted from the browser uploader, so other uploaders can use it too

## Testing

Existing Request tests now need to pass a `type` of payload and they use `File` instances for compactness. New tests for the failure cases that happen when a RN/Node payload is passed in as they're not implemented yet (this is just to get >80% coverage!)