### PR TITLE
refactor: Switch to command-line-args for parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1666,6 +1666,18 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/command-line-args": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
+      "integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
+      "dev": true
+    },
+    "@types/command-line-usage": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
+      "integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
+      "dev": true
+    },
     "@types/concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
@@ -2252,12 +2264,14 @@
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -2302,8 +2316,7 @@
     "array-back": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
-      "dev": true
+      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
     },
     "array-includes": {
       "version": "3.1.1",
@@ -2759,16 +2772,6 @@
         }
       }
     },
-    "cliui": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.1.tgz",
-      "integrity": "sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==",
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2795,6 +2798,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -2802,7 +2806,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "colorette": {
       "version": "1.2.1",
@@ -2819,11 +2824,33 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "requires": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+        },
+        "typical": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+          "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+        }
+      }
+    },
     "command-line-usage": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
       "integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
-      "dev": true,
       "requires": {
         "array-back": "^4.0.0",
         "chalk": "^2.4.2",
@@ -2835,7 +2862,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -2844,7 +2870,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -2855,7 +2880,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -2863,20 +2887,17 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -3043,8 +3064,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3192,7 +3212,8 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -3270,7 +3291,8 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3948,6 +3970,21 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+        }
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -4051,7 +4088,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -4530,7 +4568,8 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -5540,6 +5579,11 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -6334,8 +6378,7 @@
     "reduce-flatten": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "dev": true
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
     },
     "regenerate": {
       "version": "1.4.1",
@@ -6561,7 +6604,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -6943,13 +6987,13 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://bugsnag.jfrog.io/artifactory/api/npm/platforms-npm-virtual/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://bugsnag.jfrog.io/artifactory/api/npm/platforms-npm-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         }
@@ -7248,6 +7292,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
       "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7372,6 +7417,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       }
@@ -7451,7 +7497,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://bugsnag.jfrog.io/artifactory/api/npm/platforms-npm-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -7481,7 +7527,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
       "integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
-      "dev": true,
       "requires": {
         "array-back": "^4.0.1",
         "deep-extend": "~0.6.0",
@@ -7736,8 +7781,7 @@
     "typical": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "dev": true
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
     },
     "uid-safe": {
       "version": "2.1.5",
@@ -8171,20 +8215,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
       "integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
-      "dev": true,
       "requires": {
         "reduce-flatten": "^2.0.0",
         "typical": "^5.0.0"
-      }
-    },
-    "wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
       }
     },
     "wrappy": {
@@ -8231,30 +8264,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "y18n": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.2.tgz",
-      "integrity": "sha512-CkwaeZw6dQgqgPGeTWKMXCRmMcBgETFlTml1+ZOO+q7kGst8NREJ+eWwFNPVUQ4QGdAaklbqCZHH6Zuep1RjiA=="
-    },
-    "yargs": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
-      "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
-      "requires": {
-        "cliui": "^7.0.0",
-        "escalade": "^3.0.2",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.1",
-        "yargs-parser": "^20.0.0"
-      }
-    },
-    "yargs-parser": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
-      "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-typescript": "^7.10.4",
-    "@types/concat-stream": "^1.6.0",
     "@react-native-community/eslint-config": "^2.0.0",
+    "@types/command-line-args": "^5.0.0",
+    "@types/command-line-usage": "^5.0.1",
+    "@types/concat-stream": "^1.6.0",
     "@types/jest": "^26.0.14",
     "@types/multiparty": "0.0.32",
-    "@types/yargs": "^15.0.9",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
     "babel-jest": "^26.5.2",
@@ -46,8 +47,9 @@
     "webpack-cli": "^4.1.0"
   },
   "dependencies": {
+    "command-line-args": "^5.1.1",
+    "command-line-usage": "^6.1.0",
     "consola": "^2.15.0",
-    "read-pkg-up": "^7.0.1",
-    "yargs": "^16.0.3"
+    "read-pkg-up": "^7.0.1"
   }
 }

--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -2,27 +2,25 @@ import run from '../cli'
 
 test('cli prints help', () => {
   const logSpy = jest.spyOn(global.console, 'log').mockImplementation(jest.fn())
-  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(jest.fn() as unknown as (code?: number) => never)
-  run(['/usr/bin/env/node', 'source-map-upload', '--help'])
+  run(['--help'])
   expect(logSpy).toHaveBeenCalled()
   expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('bugsnag-source-maps <command>'))
-  expect(exitSpy).toHaveBeenCalledWith(0)
 })
 
 test('cli upload-node command', () => {
   const logSpy = jest.spyOn(global.console, 'log').mockImplementation(() => {})
-  run(['/usr/bin/env/node', 'source-map-upload', 'upload-node', '--help'])
-  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('bugsnag-source-maps upload-node'))
+  run(['upload-node', '--help'])
+  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('TODO'))
 })
 
 test('cli upload-react-native command', () => {
   const logSpy = jest.spyOn(global.console, 'log').mockImplementation(() => {})
-  run(['/usr/bin/env/node', 'source-map-upload', 'upload-react-native', '--help'])
-  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('bugsnag-source-maps upload-react-native'))
+  run(['upload-react-native', '--help'])
+  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('TODO'))
 })
 
 test('cli upload-browser command', () => {
   const logSpy = jest.spyOn(global.console, 'log').mockImplementation(() => {})
-  run(['/usr/bin/env/node', 'source-map-upload', 'upload-browser', '--help'])
+  run(['upload-browser', '--help'])
   expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('bugsnag-source-maps upload-browser'))
 })

--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -20,6 +20,11 @@ test('cli: version', async () => {
   expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('@bugsnag/source-maps v'))
 })
 
+test('cli: duplicate option', async () => {
+  await run(['--help', '--help'])
+  expect(logger.error).toHaveBeenCalledWith('Invalid options. Singular option already set [help=true]')
+})
+
 test('cli: upload-node command', async () => {
   const logSpy = jest.spyOn(global.console, 'log').mockImplementation(() => {})
   run(['upload-node', '--help'])

--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -13,6 +13,13 @@ test('cli: prints help', async () => {
   expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('bugsnag-source-maps <command>'))
 })
 
+test('cli: version', async () => {
+  const logSpy = jest.spyOn(global.console, 'log').mockImplementation(jest.fn())
+  await run(['--version'])
+  expect(logSpy).toHaveBeenCalled()
+  expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('@bugsnag/source-maps v'))
+})
+
 test('cli: upload-node command', async () => {
   const logSpy = jest.spyOn(global.console, 'log').mockImplementation(() => {})
   run(['upload-node', '--help'])

--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -1,26 +1,107 @@
 import run from '../cli'
+import logger from '../../Logger'
+import * as browser from '../../uploaders/BrowserUploader'
+import { LogLevel } from 'consola'
 
-test('cli prints help', () => {
+jest.mock('../../uploaders/BrowserUploader')
+jest.mock('../../Logger')
+
+test('cli: prints help', async () => {
   const logSpy = jest.spyOn(global.console, 'log').mockImplementation(jest.fn())
-  run(['--help'])
+  await run(['--help'])
   expect(logSpy).toHaveBeenCalled()
   expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('bugsnag-source-maps <command>'))
 })
 
-test('cli upload-node command', () => {
+test('cli: upload-node command', async () => {
   const logSpy = jest.spyOn(global.console, 'log').mockImplementation(() => {})
   run(['upload-node', '--help'])
   expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('TODO'))
 })
 
-test('cli upload-react-native command', () => {
+test('cli: upload-react-native command', async () => {
   const logSpy = jest.spyOn(global.console, 'log').mockImplementation(() => {})
-  run(['upload-react-native', '--help'])
+  await run(['upload-react-native', '--help'])
   expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('TODO'))
 })
 
-test('cli upload-browser command', () => {
+test('cli: upload-browser --help', async () => {
   const logSpy = jest.spyOn(global.console, 'log').mockImplementation(() => {})
-  run(['upload-browser', '--help'])
+  await run(['upload-browser', '--help'])
   expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('bugsnag-source-maps upload-browser'))
+})
+
+test('cli: upload-browser invalid option', async () => {
+  await run(['upload-browser', 'foo'])
+  expect(logger.error).toHaveBeenCalledWith('Invalid argument provided. Unknown value: foo')
+})
+
+test('cli: upload-browser exit code for failure', async () => {
+  const mockedUpload = browser.uploadOne as jest.MockedFunction<typeof browser.uploadOne>
+  mockedUpload.mockRejectedValue(new Error('fail'))
+  await run(['upload-browser', '--api-key', '123', '--bundle-url', 'http://my.url/dist/bundle.js', '--source-map', 'bundle.js.map'])
+  expect(process.exitCode).toBe(1)
+})
+
+test('cli: upload-browser single mode', async () => {
+  await run(['upload-browser', '--api-key', '123', '--bundle-url', 'http://my.url/dist/bundle.js', '--source-map', 'bundle.js.map'])
+  expect(browser.uploadOne).toHaveBeenCalledTimes(1)
+  expect(browser.uploadOne).toHaveBeenCalledWith(
+    expect.objectContaining({ apiKey: '123', bundleUrl: 'http://my.url/dist/bundle.js', sourceMap: 'bundle.js.map' })
+  )
+})
+
+test('cli: upload-browser single mode missing opts', async () => {
+  await run(['upload-browser', '--api-key', '123', '--bundle-url', 'http://my.url/dist/bundle.js'])
+  expect(process.exitCode).toBe(1)
+  expect(logger.error).toHaveBeenCalledWith('--source-map is required')
+
+  await run(['upload-browser', '--api-key', '123', '--source-map', 'bundle.js.map'])
+  expect(process.exitCode).toBe(1)
+  expect(logger.error).toHaveBeenCalledWith('--bundle-url is required')
+
+  await run(['upload-browser', '--api-key', '123'])
+  expect(process.exitCode).toBe(1)
+  expect(logger.error).toHaveBeenCalledWith('Not enough options supplied')
+
+  await run(['upload-browser'])
+  expect(process.exitCode).toBe(1)
+  expect(logger.error).toHaveBeenCalledWith('--api-key is required')
+})
+
+test('cli: upload-browser multiple mode', async () => {
+  await run(['upload-browser', '--api-key', '123', '--base-url', 'http://my.url/dist', '--directory', 'dist'])
+  // TODO
+})
+
+test('cli: upload-browser multiple mode missing opts', async () => {
+  await run(['upload-browser', '--api-key', '123', '--directory', 'dist'])
+  expect(process.exitCode).toBe(1)
+  expect(logger.error).toHaveBeenCalledWith('--base-url is required')
+
+  await run(['upload-browser', '--api-key', '123', '--base-url', 'http://my.url/dist'])
+  expect(process.exitCode).toBe(1)
+  expect(logger.error).toHaveBeenCalledWith('--directory is required')
+})
+
+test('cli: upload-browser incompatible opts', async () => {
+  await run(['upload-browser', '--api-key', '123', '--bundle-url', 'http://my.url/dist/bundle.js', '--directory', 'dist'])
+  expect(process.exitCode).toBe(1)
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Incompatible options are set.'))
+})
+
+test('cli: upload-browser --quiet', async () => {
+  await run(['upload-browser', '--api-key', '123', '--bundle-url', 'http://my.url/dist/bundle.js', '--source-map', 'bundle.js.map', '--quiet'])
+  expect(browser.uploadOne).toHaveBeenCalledTimes(1)
+  expect(logger.level).toBe(LogLevel.Success)
+})
+
+test('cli: unrecognised command', async () => {
+  await run(['xyz'])
+  expect(logger.error).toHaveBeenCalledWith('Unrecognized command "xyz".')
+})
+
+test('cli: unrecognised command', async () => {
+  await run(['--opt'])
+  expect(logger.error).toHaveBeenCalledWith('Command expected, nothing provided.')
 })

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -1,8 +1,7 @@
-import commandLineArgs, { OptionDefinition } from 'command-line-args'
+import commandLineArgs from 'command-line-args'
 import commandLineUsage from 'command-line-usage'
-import * as browser from '../uploaders/BrowserUploader'
 import logger from '../Logger'
-import { LogLevel } from 'consola'
+import uploadBrowser from '../commands/UploadBrowserCommand'
 
 const topLevelDefs = [
   {
@@ -16,11 +15,6 @@ const topLevelDefs = [
     description: 'show this message'
   },
   {
-    name: 'quiet',
-    type: Boolean,
-    description: 'less verbose logging'
-  },
-  {
     name: 'version',
     type: Boolean,
     description: 'output the version of the CLI module'
@@ -30,51 +24,10 @@ const topLevelDefs = [
 export default async function run (argv: string[]): Promise<void> {
   const opts = commandLineArgs(topLevelDefs, { argv, stopAtFirstUnknown: true })
 
-  if (opts.quiet) logger.level = LogLevel.Success
-
   switch (opts.command) {
-    case 'upload-browser': {
-
-      const defs: OptionDefinition[] = [
-        ...commonCommandDefs,
-        ...browserCommandCommonDefs,
-        ...browserCommandSingleDefs,
-        ...browserCommandMultipleDefs
-      ]
-      let browserOpts
-      try {
-        browserOpts = commandLineArgs(defs, { argv: opts._unknown || [], camelCase: true })
-        if (opts.help) return browserUsage()
-        validateBrowserOpts(browserOpts)
-      } catch (e) {
-        process.exitCode = 1
-        if (e.name === 'UNKNOWN_VALUE') {
-          logger.error(`Invalid argument provided. ${e.message}`)
-        } else {
-          logger.error(e.message)
-        }
-        return browserUsage()
-      }
-      try {
-        if (browserOpts.sourceMap) {
-          // single mode
-          await browser.uploadOne({
-            apiKey: browserOpts.apiKey,
-            sourceMap: browserOpts.sourceMap,
-            bundleUrl: browserOpts.bundleUrl,
-            bundle: browserOpts.bundle,
-            projectRoot: browserOpts.projectRoot,
-            overwrite: browserOpts.overwrite,
-            appVersion: browserOpts.appVersion,
-            endpoint: browserOpts.endpoint,
-            logger
-          })
-        }
-      } catch (e) {
-        process.exitCode = 1
-      }
+    case 'upload-browser':
+      await uploadBrowser(opts._unknown || [], opts)
       break
-    }
     case 'upload-node':
       console.log('TODO')
       break
@@ -84,7 +37,7 @@ export default async function run (argv: string[]): Promise<void> {
     default:
       if (opts.help) return usage()
       if (opts.command) {
-        logger.error(`Unrecognized command "${opts.command}"`)
+        logger.error(`Unrecognized command "${opts.command}".`)
       } else {
         logger.error(`Command expected, nothing provided.`)
       }
@@ -100,69 +53,4 @@ function usage (): void {
       { header: 'Options', optionList: topLevelDefs, hide: [ 'command' ] }
     ])
   )
-}
-
-function browserUsage (): void {
-  console.log(
-    commandLineUsage([
-      { content: 'bugsnag-source-maps upload-browser [...opts]' },
-      {
-        header: 'Options',
-        optionList: [ ...commonCommandDefs, ...browserCommandCommonDefs ]
-      },
-      {
-        header: 'Single upload',
-        content: 'Options for uploading a source map for a single bundle'
-      },
-      {
-        optionList: [ ...browserCommandSingleDefs ]
-      },
-      {
-        header: 'Multiple upload',
-        content: 'Options for recursing directory and upload multiple source maps'
-      },
-      {
-        optionList: [ ...browserCommandMultipleDefs ]
-      }
-    ])
-  )
-}
-
-const commonCommandDefs = [
-  { name: 'api-key', type: String, description: 'your project\'s API key {bold required}' },
-  { name: 'overwrite', type: Boolean, description: 'whether to replace exiting source maps uploaded with the same version' },
-  { name: 'project-root', type: String, description: 'the top level directory of your project' },
-  { name: 'endpoint', type: String, description: 'customize the endpoint for Bugsnag On-Premise' }
-]
-
-const browserCommandCommonDefs = [ { name: 'app-version', type: String } ]
-
-const browserCommandSingleDefs = [
-  { name: 'source-map', type: String, description: 'the path to the source map {bold required}', typeLabel: '{underline file}' },
-  { name: 'bundle-url', type: String, description: 'the URL the bundle is served at (may contain * wildcards) {bold required}', typeLabel: '{underline url}' },
-  { name: 'bundle', type: String, description: 'the path to the bundle', typeLabel: '{underline file}' },
-]
-const browserCommandMultipleDefs = [
-  { name: 'directory', type: String, description: 'the directory to start searching for source maps in {bold required}', typeLabel: '{underline path}' },
-  { name: 'base-url', type: String, description: 'the base URL that JS bundles are served from (may contain * wildcards) {bold required}', typeLabel: '{underline url}' },
-]
-
-function validateBrowserOpts (opts: Record<string, unknown>): void {
-  if (!opts['apiKey']) throw new Error('--api-key is a required parameter')
-  const anySingleSet = opts['sourceMap'] || opts['bundleUrl'] || opts['bundle']
-  const anyMultipleSet = opts['baseUrl'] || opts['directory']
-  if (anySingleSet && anyMultipleSet) {
-    throw new Error('Incompatible options are set. Use either single mode options (--source-map, --bundle, --bundle-url) or multiple mode options (--directory,--base-url).')
-  }
-  if (!anySingleSet && !anyMultipleSet) throw new Error('Not enough options supplied')
-
-  if (anySingleSet) {
-    // single mode
-    if (!opts['sourceMap']) throw new Error('--sourcemap is required')
-    if (!opts['bundleUrl']) throw new Error('--bundle-url is required')
-  } else {
-    // multiple mode
-    if (!opts['directory']) throw new Error('--directory is required')
-    if (!opts['base-url']) throw new Error('--base-url is required')
-  }
 }

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -24,6 +24,13 @@ const topLevelDefs = [
 export default async function run (argv: string[]): Promise<void> {
   const opts = commandLineArgs(topLevelDefs, { argv, stopAtFirstUnknown: true })
 
+  if (opts.version) {
+    return console.log(
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      `@bugsnag/source-maps v${require('../../package.json').version}`
+    )
+  }
+
   switch (opts.command) {
     case 'upload-browser':
       await uploadBrowser(opts._unknown || [], opts)

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -22,33 +22,38 @@ const topLevelDefs = [
 ]
 
 export default async function run (argv: string[]): Promise<void> {
-  const opts = commandLineArgs(topLevelDefs, { argv, stopAtFirstUnknown: true })
+  try {
+    const opts = commandLineArgs(topLevelDefs, { argv, stopAtFirstUnknown: true })
 
-  if (opts.version) {
-    return console.log(
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      `@bugsnag/source-maps v${require('../../package.json').version}`
-    )
-  }
+    if (opts.version) {
+      return console.log(
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        `@bugsnag/source-maps v${require('../../package.json').version}`
+      )
+    }
 
-  switch (opts.command) {
-    case 'upload-browser':
-      await uploadBrowser(opts._unknown || [], opts)
-      break
-    case 'upload-node':
-      console.log('TODO')
-      break
-    case 'upload-react-native':
-      console.log('TODO')
-      break
-    default:
-      if (opts.help) return usage()
-      if (opts.command) {
-        logger.error(`Unrecognized command "${opts.command}".`)
-      } else {
-        logger.error(`Command expected, nothing provided.`)
-      }
-      usage()
+    switch (opts.command) {
+      case 'upload-browser':
+        await uploadBrowser(opts._unknown || [], opts)
+        break
+      case 'upload-node':
+        console.log('TODO')
+        break
+      case 'upload-react-native':
+        console.log('TODO')
+        break
+      default:
+        if (opts.help) return usage()
+        if (opts.command) {
+          logger.error(`Unrecognized command "${opts.command}".`)
+        } else {
+          logger.error(`Command expected, nothing provided.`)
+        }
+        usage()
+    }
+  } catch (e) {
+    logger.error(`Invalid options. ${e.message}`)
+    process.exitCode = 1
   }
 }
 

--- a/src/commands/CommandDefinitions.ts
+++ b/src/commands/CommandDefinitions.ts
@@ -1,0 +1,7 @@
+export const commonCommandDefs = [
+  { name: 'api-key', type: String, description: 'your project\'s API key {bold required}' },
+  { name: 'overwrite', type: Boolean, description: 'whether to replace exiting source maps uploaded with the same version' },
+  { name: 'project-root', type: String, description: 'the top level directory of your project' },
+  { name: 'endpoint', type: String, description: 'customize the endpoint for Bugsnag On-Premise' },
+  { name: 'quiet', type: Boolean, description: 'less verbose logging' },
+]

--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -1,0 +1,134 @@
+import commandLineArgs, { OptionDefinition } from 'command-line-args'
+import commandLineUsage from 'command-line-usage'
+import * as browser from '../uploaders/BrowserUploader'
+import logger from '../Logger'
+import { LogLevel } from 'consola'
+import { commonCommandDefs } from './CommandDefinitions'
+
+export default async function uploadBrowser (argv: string[], opts: Record<string, unknown>): Promise<void> {
+  const defs: OptionDefinition[] = [
+    ...commonCommandDefs,
+    ...browserCommandCommonDefs,
+    ...browserCommandSingleDefs,
+    ...browserCommandMultipleDefs
+  ]
+  let browserOpts
+  try {
+    browserOpts = commandLineArgs(defs, { argv, camelCase: true })
+    if (opts.help) return browserUsage()
+    if (browserOpts.quiet) logger.level = LogLevel.Success
+    validateBrowserOpts(browserOpts)
+  } catch (e) {
+    process.exitCode = 1
+    if (e.name === 'UNKNOWN_VALUE') {
+      logger.error(`Invalid argument provided. ${e.message}`)
+    } else {
+      logger.error(e.message)
+    }
+    return browserUsage()
+  }
+  try {
+    if (browserOpts.sourceMap) {
+      // single mode
+      await browser.uploadOne({
+        apiKey: browserOpts.apiKey,
+        sourceMap: browserOpts.sourceMap,
+        bundleUrl: browserOpts.bundleUrl,
+        bundle: browserOpts.bundle,
+        projectRoot: browserOpts.projectRoot,
+        overwrite: browserOpts.overwrite,
+        appVersion: browserOpts.appVersion,
+        endpoint: browserOpts.endpoint,
+        logger
+      })
+    } else {
+      // multiple mode
+      // TODO
+    }
+  } catch (e) {
+    process.exitCode = 1
+  }
+}
+
+function browserUsage (): void {
+  console.log(
+    commandLineUsage([
+      { content: 'bugsnag-source-maps upload-browser [...opts]' },
+      {
+        header: 'Options',
+        optionList: [ ...commonCommandDefs, ...browserCommandCommonDefs ]
+      },
+      {
+        header: 'Single upload',
+        content: 'Options for uploading a source map for a single bundle'
+      },
+      {
+        optionList: [ ...browserCommandSingleDefs ]
+      },
+      {
+        header: 'Multiple upload',
+        content: 'Options for recursing directory and upload multiple source maps'
+      },
+      {
+        optionList: [ ...browserCommandMultipleDefs ]
+      }
+    ])
+  )
+}
+
+const browserCommandCommonDefs = [ { name: 'app-version', type: String } ]
+
+const browserCommandSingleDefs = [
+  {
+    name: 'source-map',
+    type: String,
+    description: 'the path to the source map {bold required}',
+    typeLabel: '{underline file}'
+  },
+  {
+    name: 'bundle-url',
+    type: String,
+    description: 'the URL the bundle is served at (may contain * wildcards) {bold required}',
+    typeLabel: '{underline url}'
+  },
+  {
+    name: 'bundle',
+    type: String,
+    description: 'the path to the bundle',
+    typeLabel: '{underline file}'
+  },
+]
+const browserCommandMultipleDefs = [
+  {
+    name: 'directory',
+    type: String,
+    description: 'the directory to start searching for source maps in {bold required}',
+    typeLabel: '{underline path}'
+  },
+  {
+    name: 'base-url',
+    type: String,
+    description: 'the base URL that JS bundles are served from (may contain * wildcards) {bold required}',
+    typeLabel: '{underline url}'
+  },
+]
+
+function validateBrowserOpts (opts: Record<string, unknown>): void {
+  if (!opts['apiKey']) throw new Error('--api-key is required')
+  const anySingleSet = opts['sourceMap'] || opts['bundleUrl'] || opts['bundle']
+  const anyMultipleSet = opts['baseUrl'] || opts['directory']
+  if (anySingleSet && anyMultipleSet) {
+    throw new Error('Incompatible options are set. Use either single mode options (--source-map, --bundle, --bundle-url) or multiple mode options (--directory,--base-url).')
+  }
+  if (!anySingleSet && !anyMultipleSet) throw new Error('Not enough options supplied')
+
+  if (anySingleSet) {
+    // single mode
+    if (!opts['sourceMap']) throw new Error('--source-map is required')
+    if (!opts['bundleUrl']) throw new Error('--bundle-url is required')
+  } else {
+    // multiple mode
+    if (!opts['directory']) throw new Error('--directory is required')
+    if (!opts['baseUrl']) throw new Error('--base-url is required')
+  }
+}


### PR DESCRIPTION
## Goal

Refactors the CLI arg parsing to a different library, since the previously used module (yargs) contained validation, but was unable to fully validate the various option requirements, so required manual logic anyway.

## Design

For consistency the same module as our other CLI (bugsnag-expo-cli) is used: [command-line-args](https://github.com/75lb/command-line-args) (and its companion [command-line-usage](https://github.com/75lb/command-line-usage/) for pretty printing the various options)

## Changeset

`cli.ts` has been totally rewritten. The browser arg parsing has been factored out into the `commands/` directory.

## Testing

Complete unit test coverage added.

----

Some example output…

<img width="682" alt="image" src="https://user-images.githubusercontent.com/609579/97613744-f6f54480-1a10-11eb-8cf4-cdbdbb4a30f1.png">

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/609579/97613842-14c2a980-1a11-11eb-895a-5a2a4f6da1b9.png">

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/609579/97613875-2310c580-1a11-11eb-8d8a-07731ea60b8b.png">
