### PR TITLE
Add React Native fetch mode

### DIFF
--- a/src/NetworkError.ts
+++ b/src/NetworkError.ts
@@ -1,0 +1,8 @@
+export enum NetworkErrorCode { UNKNOWN, DUPLICATE, TIMEOUT, MISC_BAD_REQUEST, EMPTY_FILE, INVALID_API_KEY, SERVER_ERROR }
+
+export class NetworkError extends Error {
+  isRetryable = true
+  code: NetworkErrorCode = NetworkErrorCode.UNKNOWN
+  cause: Error | null = null
+  responseText: string | null = null
+}

--- a/src/NetworkError.ts
+++ b/src/NetworkError.ts
@@ -1,4 +1,14 @@
-export enum NetworkErrorCode { UNKNOWN, DUPLICATE, TIMEOUT, MISC_BAD_REQUEST, EMPTY_FILE, INVALID_API_KEY, SERVER_ERROR }
+export enum NetworkErrorCode {
+  UNKNOWN,
+  DUPLICATE,
+  TIMEOUT,
+  MISC_BAD_REQUEST,
+  EMPTY_FILE,
+  INVALID_API_KEY,
+  SERVER_ERROR,
+  CONNECTION_REFUSED,
+  NOT_FOUND,
+}
 
 export class NetworkError extends Error {
   isRetryable = true

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -207,7 +207,15 @@ function addErrorHandler(req: http.ClientRequest, reject: (reason: NetworkError)
   req.on('error', e => {
     const err = new NetworkError('Unknown connection error')
     err.cause = e
-    err.code = NetworkErrorCode.UNKNOWN
+
+    const failureReason = (e as any).code
+
+    if (failureReason === 'ECONNREFUSED') {
+      err.code = NetworkErrorCode.CONNECTION_REFUSED
+    } else {
+      err.code = NetworkErrorCode.UNKNOWN
+    }
+
     reject(err)
   })
 }

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -208,7 +208,7 @@ function addErrorHandler(req: http.ClientRequest, reject: (reason: NetworkError)
     const err = new NetworkError('Unknown connection error')
     err.cause = e
 
-    const failureReason = (e as any).code
+    const failureReason = (e as NodeJS.ErrnoException).code
 
     if (failureReason === 'ECONNREFUSED') {
       err.code = NetworkErrorCode.CONNECTION_REFUSED

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -3,7 +3,7 @@ import http from 'http'
 import concat from 'concat-stream'
 import url from 'url'
 import FormData from 'form-data'
-import { UploadError, UploadErrorCode } from './UploadError'
+import { NetworkError, NetworkErrorCode } from './NetworkError'
 import File from './File'
 
 export const enum PayloadType { Browser, ReactNative, Node }
@@ -126,7 +126,7 @@ export async function send (endpoint: string, payload: Payload, requestOpts: htt
     }, res => {
       res.pipe(concat((bodyBuffer: Buffer) => {
         if (res.statusCode === 200) return resolve()
-        const err = new UploadError(`HTTP status ${res.statusCode} received from upload API`)
+        const err = new NetworkError(`HTTP status ${res.statusCode} received from upload API`)
         err.responseText = bodyBuffer.toString()
         if (!isRetryable(res.statusCode)) {
           err.isRetryable = false
@@ -134,33 +134,33 @@ export async function send (endpoint: string, payload: Payload, requestOpts: htt
         if (res.statusCode && (res.statusCode >= 400 && res.statusCode < 500)) {
           switch (res.statusCode) {
             case 401:
-              err.code = UploadErrorCode.INVALID_API_KEY
+              err.code = NetworkErrorCode.INVALID_API_KEY
               break
             case 409:
-              err.code = UploadErrorCode.DUPLICATE
+              err.code = NetworkErrorCode.DUPLICATE
               break
             case 422:
-              err.code = UploadErrorCode.EMPTY_FILE
+              err.code = NetworkErrorCode.EMPTY_FILE
               break
             default:
-              err.code = UploadErrorCode.MISC_BAD_REQUEST
+              err.code = NetworkErrorCode.MISC_BAD_REQUEST
           }
         } else {
-          err.code = UploadErrorCode.SERVER_ERROR
+          err.code = NetworkErrorCode.SERVER_ERROR
         }
         return reject(err)
       }))
     })
     formData.pipe(req)
     req.on('error', e => {
-      const err = new UploadError('Unknown connection error')
+      const err = new NetworkError('Unknown connection error')
       err.cause = e
-      err.code = UploadErrorCode.UNKNOWN
+      err.code = NetworkErrorCode.UNKNOWN
       reject(err)
     })
     req.setTimeout(TIMEOUT_MS, () => {
-      const err = new UploadError('Connection timed out')
-      err.code = UploadErrorCode.TIMEOUT
+      const err = new NetworkError('Connection timed out')
+      err.code = NetworkErrorCode.TIMEOUT
       reject(err)
       req.abort()
     })
@@ -189,7 +189,7 @@ export function fetch(endpoint: string): Promise<string> {
           return resolve(bodyBuffer.toString())
         }
 
-        const err = new UploadError(`HTTP status ${res.statusCode} received from bundle server`)
+        const err = new NetworkError(`HTTP status ${res.statusCode} received from bundle server`)
         err.responseText = bodyBuffer.toString()
 
         if (!isRetryable(res.statusCode)) {
@@ -197,9 +197,9 @@ export function fetch(endpoint: string): Promise<string> {
         }
 
         if (res.statusCode && (res.statusCode >= 400 && res.statusCode < 500)) {
-          err.code = UploadErrorCode.MISC_BAD_REQUEST
+          err.code = NetworkErrorCode.MISC_BAD_REQUEST
         } else {
-          err.code = UploadErrorCode.SERVER_ERROR
+          err.code = NetworkErrorCode.SERVER_ERROR
         }
 
         return reject(err)
@@ -207,15 +207,15 @@ export function fetch(endpoint: string): Promise<string> {
     })
 
     req.on('error', e => {
-      const err = new UploadError('Unknown connection error')
+      const err = new NetworkError('Unknown connection error')
       err.cause = e
-      err.code = UploadErrorCode.UNKNOWN
+      err.code = NetworkErrorCode.UNKNOWN
       reject(err)
     })
 
     req.setTimeout(TIMEOUT_MS, () => {
-      const err = new UploadError('Connection timed out')
-      err.code = UploadErrorCode.TIMEOUT
+      const err = new NetworkError('Connection timed out')
+      err.code = NetworkErrorCode.TIMEOUT
       reject(err)
       req.abort()
     })

--- a/src/UploadError.ts
+++ b/src/UploadError.ts
@@ -1,8 +1,0 @@
-export enum UploadErrorCode { UNKNOWN, DUPLICATE, TIMEOUT, MISC_BAD_REQUEST, EMPTY_FILE, INVALID_API_KEY, SERVER_ERROR }
-
-export class UploadError extends Error {
-  isRetryable = true
-  code: UploadErrorCode = UploadErrorCode.UNKNOWN
-  cause: Error | null = null
-  responseText: string | null = null
-}

--- a/src/__test__/Request.test.ts
+++ b/src/__test__/Request.test.ts
@@ -1,5 +1,5 @@
 import request, { PayloadType, send, isRetryable, fetch } from '../Request'
-import { UploadErrorCode } from '../UploadError'
+import { NetworkErrorCode } from '../NetworkError'
 import http from 'http'
 import { AddressInfo } from 'net'
 import multiparty from 'multiparty'
@@ -176,7 +176,7 @@ test('request: send() unsuccessful upload (invalid, no retry)', async () => {
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(false)
-    expect(e.code).toBe(UploadErrorCode.MISC_BAD_REQUEST)
+    expect(e.code).toBe(NetworkErrorCode.MISC_BAD_REQUEST)
   }
 })
 
@@ -200,7 +200,7 @@ test('request: send() unsuccessful upload (invalid, empty file)', async () => {
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(false)
-    expect(e.code).toBe(UploadErrorCode.EMPTY_FILE)
+    expect(e.code).toBe(NetworkErrorCode.EMPTY_FILE)
   }
 })
 
@@ -224,7 +224,7 @@ test('request: send() unsuccessful upload (misc 40x code)', async () => {
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(false)
-    expect(e.code).toBe(UploadErrorCode.MISC_BAD_REQUEST)
+    expect(e.code).toBe(NetworkErrorCode.MISC_BAD_REQUEST)
   }
 })
 
@@ -248,7 +248,7 @@ test('request: send() unsuccessful upload (unauthed, no retry)', async () => {
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(false)
-    expect(e.code).toBe(UploadErrorCode.INVALID_API_KEY)
+    expect(e.code).toBe(NetworkErrorCode.INVALID_API_KEY)
   }
 })
 
@@ -272,7 +272,7 @@ test('request: send() unsuccessful upload (retryable status)', async () => {
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(true)
-    expect(e.code).toBe(UploadErrorCode.SERVER_ERROR)
+    expect(e.code).toBe(NetworkErrorCode.SERVER_ERROR)
     expect(e.responseText).toBe('server error')
   }
 })
@@ -296,7 +296,7 @@ test('request: send() unsuccessful upload (timeout)', async () => {
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(true)
-    expect(e.code).toBe(UploadErrorCode.TIMEOUT)
+    expect(e.code).toBe(NetworkErrorCode.TIMEOUT)
   }
 })
 
@@ -320,7 +320,7 @@ test('request: send() unsuccessful upload (duplicate)', async () => {
     }, {})
   } catch (e) {
     expect(e.isRetryable).toBe(false)
-    expect(e.code).toBe(UploadErrorCode.DUPLICATE)
+    expect(e.code).toBe(NetworkErrorCode.DUPLICATE)
   }
 })
 
@@ -345,7 +345,7 @@ test('request: request() multiple attempts at retryable errors', async () => {
     }, {})
   } catch (e) {
     expect(requestsReceived).toBe(5)
-    expect(e.code).toBe(UploadErrorCode.TIMEOUT)
+    expect(e.code).toBe(NetworkErrorCode.TIMEOUT)
   }
 })
 
@@ -431,7 +431,7 @@ test('request: fetch() unsuccessful (bad request)', async () => {
     expect(response).toBe('abc')
   } catch (e) {
     expect(e.isRetryable).toBe(false)
-    expect(e.code).toBe(UploadErrorCode.MISC_BAD_REQUEST)
+    expect(e.code).toBe(NetworkErrorCode.MISC_BAD_REQUEST)
   }
 })
 
@@ -449,7 +449,7 @@ test('request: fetch() unsuccessful (server error)', async () => {
     expect(response).toBe('abc')
   } catch (e) {
     expect(e.isRetryable).toBe(true)
-    expect(e.code).toBe(UploadErrorCode.SERVER_ERROR)
+    expect(e.code).toBe(NetworkErrorCode.SERVER_ERROR)
   }
 })
 
@@ -466,6 +466,6 @@ test('request: fetch() unsuccessful (timeout)', async () => {
     expect(response).toBe('abc')
   } catch (e) {
     expect(e.isRetryable).toBe(true)
-    expect(e.code).toBe(UploadErrorCode.TIMEOUT)
+    expect(e.code).toBe(NetworkErrorCode.TIMEOUT)
   }
 })

--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -359,6 +359,39 @@ test('cli: upload-react-native success with "fetch" mode', async () => {
     projectRoot: process.cwd(),
     retrieval: {
       type: SourceMapRetrievalType.Fetch,
+      url: 'http://localhost:8081',
+    },
+    version: {
+      type: VersionType.AppVersion,
+      appVersion: '1.0.2',
+    }
+  })
+
+  expect(process.exitCode).toBe(0)
+})
+
+test('cli: upload-react-native success with "fetch" mode and custom URL', async () => {
+  await run([
+    'upload-react-native',
+    '--api-key', '1234',
+    '--platform', 'ios',
+    '--app-version', '1.0.2',
+    '--fetch',
+    '--url', 'http://example.com:1100/rn-bundler'
+  ])
+
+  expect(mockReactNativeUploadOne).toHaveBeenCalledWith({
+    apiKey: '1234',
+    dev: false,
+    endpoint: 'https://upload.bugsnag.com/react-native-source-map',
+    overwrite: false,
+    platformOptions: {
+      type: Platform.Ios,
+    },
+    projectRoot: process.cwd(),
+    retrieval: {
+      type: SourceMapRetrievalType.Fetch,
+      url: 'http://example.com:1100/rn-bundler',
     },
     version: {
       type: VersionType.AppVersion,

--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -360,6 +360,7 @@ test('cli: upload-react-native success with "fetch" mode', async () => {
     retrieval: {
       type: SourceMapRetrievalType.Fetch,
       url: 'http://localhost:8081',
+      entryPoint: 'index.js',
     },
     version: {
       type: VersionType.AppVersion,
@@ -392,6 +393,40 @@ test('cli: upload-react-native success with "fetch" mode and custom URL', async 
     retrieval: {
       type: SourceMapRetrievalType.Fetch,
       url: 'http://example.com:1100/rn-bundler',
+      entryPoint: 'index.js',
+    },
+    version: {
+      type: VersionType.AppVersion,
+      appVersion: '1.0.2',
+    }
+  })
+
+  expect(process.exitCode).toBe(0)
+})
+
+test('cli: upload-react-native success with "fetch" mode and custom entry point', async () => {
+  await run([
+    'upload-react-native',
+    '--api-key', '1234',
+    '--platform', 'ios',
+    '--app-version', '1.0.2',
+    '--fetch',
+    '--bundler-entry-point', 'cool-app.js'
+  ])
+
+  expect(mockReactNativeUploadOne).toHaveBeenCalledWith({
+    apiKey: '1234',
+    dev: false,
+    endpoint: 'https://upload.bugsnag.com/react-native-source-map',
+    overwrite: false,
+    platformOptions: {
+      type: Platform.Ios,
+    },
+    projectRoot: process.cwd(),
+    retrieval: {
+      type: SourceMapRetrievalType.Fetch,
+      url: 'http://localhost:8081',
+      entryPoint: 'cool-app.js',
     },
     version: {
       type: VersionType.AppVersion,

--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -378,7 +378,7 @@ test('cli: upload-react-native success with "fetch" mode and custom URL', async 
     '--platform', 'ios',
     '--app-version', '1.0.2',
     '--fetch',
-    '--url', 'http://example.com:1100/rn-bundler'
+    '--bundler-url', 'http://example.com:1100/rn-bundler'
   ])
 
   expect(mockReactNativeUploadOne).toHaveBeenCalledWith({

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -132,6 +132,12 @@ const reactNativeFetchOpts = [
     description: 'the URL of the React Native bundle server',
     typeLabel: '{underline url}',
   },
+  {
+    name: 'bundler-entry-point',
+    type: String,
+    description: 'the entry point of your React Native app',
+    typeLabel: '{underline file}',
+  },
 ]
 
 function validateReactNativeOpts (opts: Record<string, unknown>): ReactNativeUploadOptions {
@@ -260,9 +266,16 @@ function marshallRetrieval(opts: Record<string, unknown>): SourceMapRetrieval {
       url = opts.url
     }
 
+    let entryPoint = 'index.js'
+
+    if (opts.bundlerEntryPoint && typeof opts.bundlerEntryPoint === 'string') {
+      entryPoint = opts.bundlerEntryPoint
+    }
+
     return {
       type: SourceMapRetrievalType.Fetch,
       url,
+      entryPoint,
     }
   }
 

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -121,7 +121,17 @@ const reactNativeProvideOpts = [
 ]
 
 const reactNativeFetchOpts = [
-  { name: 'fetch', type: Boolean },
+  {
+    name: 'fetch',
+    type: Boolean,
+    description: 'enable fetch mode {bold required}',
+  },
+  {
+    name: 'url',
+    type: String,
+    description: 'the URL of the React Native bundle server',
+    typeLabel: '{underline url}',
+  },
 ]
 
 function validateReactNativeOpts (opts: Record<string, unknown>): ReactNativeUploadOptions {
@@ -244,7 +254,16 @@ function marshallPlatformOptions(platform: Platform, version: Version, opts: Rec
 
 function marshallRetrieval(opts: Record<string, unknown>): SourceMapRetrieval {
   if (opts.fetch) {
-    return { type: SourceMapRetrievalType.Fetch }
+    let url = 'http://localhost:8081'
+
+    if (opts.url && typeof opts.url === 'string') {
+      url = opts.url
+    }
+
+    return {
+      type: SourceMapRetrievalType.Fetch,
+      url,
+    }
   }
 
   if (!opts.sourceMap || typeof opts.sourceMap !== 'string') {

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -127,7 +127,7 @@ const reactNativeFetchOpts = [
     description: 'enable fetch mode {bold required}',
   },
   {
-    name: 'url',
+    name: 'bundler-url',
     type: String,
     description: 'the URL of the React Native bundle server',
     typeLabel: '{underline url}',
@@ -262,8 +262,8 @@ function marshallRetrieval(opts: Record<string, unknown>): SourceMapRetrieval {
   if (opts.fetch) {
     let url = 'http://localhost:8081'
 
-    if (opts.url && typeof opts.url === 'string') {
-      url = opts.url
+    if (opts.bundlerUrl && typeof opts.bundlerUrl === 'string') {
+      url = opts.bundlerUrl
     }
 
     let entryPoint = 'index.js'

--- a/src/react-native/SourceMapRetrieval.ts
+++ b/src/react-native/SourceMapRetrieval.ts
@@ -9,8 +9,9 @@ interface ProvidedSourceMapBundlePair {
 
 // We should fetch the source map & bundle from the RN bundle server
 interface Fetch {
-  readonly type: SourceMapRetrievalType.Fetch,
-  readonly url: string,
+  readonly type: SourceMapRetrievalType.Fetch
+  readonly url: string
+  readonly entryPoint: string
 }
 
 export type SourceMapRetrieval = ProvidedSourceMapBundlePair | Fetch

--- a/src/react-native/SourceMapRetrieval.ts
+++ b/src/react-native/SourceMapRetrieval.ts
@@ -9,7 +9,8 @@ interface ProvidedSourceMapBundlePair {
 
 // We should fetch the source map & bundle from the RN bundle server
 interface Fetch {
-  readonly type: SourceMapRetrievalType.Fetch
+  readonly type: SourceMapRetrievalType.Fetch,
+  readonly url: string,
 }
 
 export type SourceMapRetrieval = ProvidedSourceMapBundlePair | Fetch

--- a/src/uploaders/FormatErrorLog.ts
+++ b/src/uploaders/FormatErrorLog.ts
@@ -1,26 +1,26 @@
-import { UploadErrorCode, UploadError } from '../UploadError'
+import { NetworkErrorCode, NetworkError } from '../NetworkError'
 
-function formatErrorLog (e: UploadError): string {
+function formatErrorLog (e: NetworkError): string {
   let str = ''
   switch (e.code) {
-    case UploadErrorCode.EMPTY_FILE:
+    case NetworkErrorCode.EMPTY_FILE:
       str += 'The uploaded source map was empty.'
       break
-    case UploadErrorCode.INVALID_API_KEY:
+    case NetworkErrorCode.INVALID_API_KEY:
       str += 'The provided API key was invalid.'
       break
-    case UploadErrorCode.MISC_BAD_REQUEST:
+    case NetworkErrorCode.MISC_BAD_REQUEST:
       str += 'The request was rejected by the server as invalid.'
       str += `\n\n  responseText = ${e.responseText}`
       break
-    case UploadErrorCode.DUPLICATE:
+    case NetworkErrorCode.DUPLICATE:
       str += 'A source map matching the same criteria has already been uploaded. If you want to replace it, use the "overwrite" flag.'
       break
-    case UploadErrorCode.SERVER_ERROR:
+    case NetworkErrorCode.SERVER_ERROR:
       str += 'A server side error occurred while processing the upload.'
       str += `\n\n  responseText = ${e.responseText}`
       break
-    case UploadErrorCode.TIMEOUT:
+    case NetworkErrorCode.TIMEOUT:
       str += 'The request timed out.'
       break
     default:

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -76,8 +76,11 @@ class ReactNativeUploader {
     switch (retrieval.type) {
       case SourceMapRetrievalType.Fetch: {
         const queryString = qs.stringify({ platform, dev })
-        const sourceMapUrl = `${retrieval.url}/index.js.map?${queryString}`
-        const bundleUrl = `${retrieval.url}/index.bundle?${queryString}`
+        const entryPoint = retrieval.entryPoint.replace(/\.js$/, '')
+
+        const sourceMapUrl = `${retrieval.url}/${entryPoint}.js.map?${queryString}`
+        const bundleUrl = `${retrieval.url}/${entryPoint}.bundle?${queryString}`
+
         let sourceMap
         let bundle
 

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -1,6 +1,6 @@
 import { uploadOne, uploadMultiple } from '../BrowserUploader'
 import request from '../../Request'
-import { UploadError, UploadErrorCode } from '../../UploadError'
+import { NetworkError, NetworkErrorCode } from '../../NetworkError'
 import path from 'path'
 
 jest.mock('../../Request')
@@ -85,7 +85,7 @@ test('uploadOne(): source map file could not be located', async () => {
 
 test('uploadOne(): failure (unexpected network error)', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('misc upload error')
+  const err = new NetworkError('misc upload error')
   err.cause = new Error('network error')
   mockedRequest.mockRejectedValue(err)
   try {
@@ -163,8 +163,8 @@ test('uploadOne(): failure (sourcemap is invalid json)', async () => {
 
 test('uploadOne(): failure (empty bundle)', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('network error')
-  err.code = UploadErrorCode.EMPTY_FILE
+  const err = new NetworkError('network error')
+  err.code = NetworkErrorCode.EMPTY_FILE
   err.responseText = 'empty'
   mockedRequest.mockRejectedValue(err)
   try {
@@ -179,15 +179,15 @@ test('uploadOne(): failure (empty bundle)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.EMPTY_FILE)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.EMPTY_FILE)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('The uploaded source map was empty'), expect.any(Error))
   }
 })
 
 test('uploadOne(): failure (invalid api key)', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('unauthed')
-  err.code = UploadErrorCode.INVALID_API_KEY
+  const err = new NetworkError('unauthed')
+  err.code = NetworkErrorCode.INVALID_API_KEY
   err.responseText = 'api key wrong'
   mockedRequest.mockRejectedValue(err)
   try {
@@ -202,15 +202,15 @@ test('uploadOne(): failure (invalid api key)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.INVALID_API_KEY)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.INVALID_API_KEY)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('The provided API key was invalid'), expect.any(Error))
   }
 })
 
 test('uploadOne(): failure (misc bad request)', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('misc bad request')
-  err.code = UploadErrorCode.MISC_BAD_REQUEST
+  const err = new NetworkError('misc bad request')
+  err.code = NetworkErrorCode.MISC_BAD_REQUEST
   err.responseText = 'server no likey'
   mockedRequest.mockRejectedValue(err)
   try {
@@ -225,15 +225,15 @@ test('uploadOne(): failure (misc bad request)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.MISC_BAD_REQUEST)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.MISC_BAD_REQUEST)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('The request was rejected by the server as invalid.\n\n  responseText = server no likey'), expect.any(Error))
   }
 })
 
 test('uploadOne(): failure (duplicate)', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('duplicate')
-  err.code = UploadErrorCode.DUPLICATE
+  const err = new NetworkError('duplicate')
+  err.code = NetworkErrorCode.DUPLICATE
   err.responseText = 'duplicate'
   mockedRequest.mockRejectedValue(err)
   try {
@@ -248,15 +248,15 @@ test('uploadOne(): failure (duplicate)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.DUPLICATE)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.DUPLICATE)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('A source map matching the same criteria has already been uploaded. If you want to replace it, use the "overwrite" flag'), expect.any(Error))
   }
 })
 
 test('uploadOne(): failure (server error)', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('server error')
-  err.code = UploadErrorCode.SERVER_ERROR
+  const err = new NetworkError('server error')
+  err.code = NetworkErrorCode.SERVER_ERROR
   err.responseText = 'internal server error'
   mockedRequest.mockRejectedValue(err)
   try {
@@ -271,15 +271,15 @@ test('uploadOne(): failure (server error)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.SERVER_ERROR)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.SERVER_ERROR)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('A server side error occurred while processing the upload.\n\n  responseText = internal server error'), expect.any(Error))
   }
 })
 
 test('uploadOne(): failure (timeout)', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('timeout')
-  err.code = UploadErrorCode.TIMEOUT
+  const err = new NetworkError('timeout')
+  err.code = NetworkErrorCode.TIMEOUT
   mockedRequest.mockRejectedValue(err)
   try {
     await uploadOne({
@@ -293,7 +293,7 @@ test('uploadOne(): failure (timeout)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.TIMEOUT)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.TIMEOUT)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('The request timed out'), expect.any(Error))
   }
 })
@@ -385,8 +385,8 @@ test('uploadMultiple(): success', async () => {
 
 test('uploadMultiple(): no source maps', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('timeout')
-  err.code = UploadErrorCode.TIMEOUT
+  const err = new NetworkError('timeout')
+  err.code = NetworkErrorCode.TIMEOUT
   mockedRequest.mockRejectedValue(err)
   await uploadMultiple({
     apiKey: '123',
@@ -432,8 +432,8 @@ test('uploadMultiple(): invalid source map', async () => {
 
 test('uploadMultiple(): failure (timeout)', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('timeout')
-  err.code = UploadErrorCode.TIMEOUT
+  const err = new NetworkError('timeout')
+  err.code = NetworkErrorCode.TIMEOUT
   mockedRequest.mockRejectedValue(err)
   try {
     await uploadMultiple({
@@ -446,15 +446,15 @@ test('uploadMultiple(): failure (timeout)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(3)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.TIMEOUT)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.TIMEOUT)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('The request timed out'), expect.any(Error))
   }
 })
 
 test('uploadMultiple(): failure (connection error)', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('misc error')
-  err.code = UploadErrorCode.UNKNOWN
+  const err = new NetworkError('misc error')
+  err.code = NetworkErrorCode.UNKNOWN
   err.cause = new Error('the cause')
   mockedRequest.mockRejectedValue(err)
   try {
@@ -468,7 +468,7 @@ test('uploadMultiple(): failure (connection error)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(6)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.UNKNOWN)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.UNKNOWN)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('An unexpected error occurred'), expect.any(Error), expect.any(Error))
   }
 })

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -5,7 +5,7 @@ import { VersionType } from '../../react-native/Version'
 import { SourceMapRetrievalType } from '../../react-native/SourceMapRetrieval'
 import request, { fetch } from '../../Request'
 import File from '../../File'
-import { UploadError, UploadErrorCode } from '../../UploadError'
+import { NetworkError, NetworkErrorCode } from '../../NetworkError'
 import path from 'path'
 
 jest.mock('../../Request')
@@ -283,7 +283,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with cod
 test('uploadOne(): failure (unexpected network error) with cause', async () => {
   const mockedRequest = request as jest.MockedFunction<typeof request>
 
-  const err = new UploadError('misc upload error')
+  const err = new NetworkError('misc upload error')
   err.cause = new Error('network error')
 
   mockedRequest.mockRejectedValue(err)
@@ -326,7 +326,7 @@ test('uploadOne(): failure (unexpected network error) with cause', async () => {
 
 test('uploadOne(): failure (unexpected network error) without cause', async () => {
   const mockedRequest = request as jest.MockedFunction<typeof request>
-  const err = new UploadError('misc upload error')
+  const err = new NetworkError('misc upload error')
 
   mockedRequest.mockRejectedValue(err)
 
@@ -474,8 +474,8 @@ test('uploadOne(): failure (sourcemap is invalid json)', async () => {
 test('uploadOne(): failure (empty bundle)', async () => {
   const mockedRequest = request as jest.MockedFunction<typeof request>
 
-  const err = new UploadError('network error')
-  err.code = UploadErrorCode.EMPTY_FILE
+  const err = new NetworkError('network error')
+  err.code = NetworkErrorCode.EMPTY_FILE
   err.responseText = 'empty'
 
   mockedRequest.mockRejectedValue(err)
@@ -507,7 +507,7 @@ test('uploadOne(): failure (empty bundle)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.EMPTY_FILE)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.EMPTY_FILE)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('The uploaded source map was empty'), expect.any(Error))
   }
 })
@@ -515,8 +515,8 @@ test('uploadOne(): failure (empty bundle)', async () => {
 test('uploadOne(): failure (invalid api key)', async () => {
   const mockedRequest = request as jest.MockedFunction<typeof request>
 
-  const err = new UploadError('unauthed')
-  err.code = UploadErrorCode.INVALID_API_KEY
+  const err = new NetworkError('unauthed')
+  err.code = NetworkErrorCode.INVALID_API_KEY
   err.responseText = 'api key wrong'
 
   mockedRequest.mockRejectedValue(err)
@@ -548,7 +548,7 @@ test('uploadOne(): failure (invalid api key)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.INVALID_API_KEY)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.INVALID_API_KEY)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('The provided API key was invalid'), expect.any(Error))
   }
 })
@@ -556,8 +556,8 @@ test('uploadOne(): failure (invalid api key)', async () => {
 test('uploadOne(): failure (misc bad request)', async () => {
   const mockedRequest = request as jest.MockedFunction<typeof request>
 
-  const err = new UploadError('misc bad request')
-  err.code = UploadErrorCode.MISC_BAD_REQUEST
+  const err = new NetworkError('misc bad request')
+  err.code = NetworkErrorCode.MISC_BAD_REQUEST
   err.responseText = 'server no likey'
 
   mockedRequest.mockRejectedValue(err)
@@ -589,7 +589,7 @@ test('uploadOne(): failure (misc bad request)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.MISC_BAD_REQUEST)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.MISC_BAD_REQUEST)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('The request was rejected by the server as invalid.\n\n  responseText = server no likey'), expect.any(Error))
   }
 })
@@ -597,8 +597,8 @@ test('uploadOne(): failure (misc bad request)', async () => {
 test('uploadOne(): failure (duplicate)', async () => {
   const mockedRequest = request as jest.MockedFunction<typeof request>
 
-  const err = new UploadError('duplicate')
-  err.code = UploadErrorCode.DUPLICATE
+  const err = new NetworkError('duplicate')
+  err.code = NetworkErrorCode.DUPLICATE
   err.responseText = 'duplicate'
 
   mockedRequest.mockRejectedValue(err)
@@ -630,7 +630,7 @@ test('uploadOne(): failure (duplicate)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.DUPLICATE)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.DUPLICATE)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('A source map matching the same criteria has already been uploaded. If you want to replace it, use the "overwrite" flag'), expect.any(Error))
   }
 })
@@ -638,8 +638,8 @@ test('uploadOne(): failure (duplicate)', async () => {
 test('uploadOne(): failure (server error)', async () => {
   const mockedRequest = request as jest.MockedFunction<typeof request>
 
-  const err = new UploadError('server error')
-  err.code = UploadErrorCode.SERVER_ERROR
+  const err = new NetworkError('server error')
+  err.code = NetworkErrorCode.SERVER_ERROR
   err.responseText = 'internal server error'
 
   mockedRequest.mockRejectedValue(err)
@@ -671,7 +671,7 @@ test('uploadOne(): failure (server error)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.SERVER_ERROR)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.SERVER_ERROR)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('A server side error occurred while processing the upload.\n\n  responseText = internal server error'), expect.any(Error))
   }
 })
@@ -679,8 +679,8 @@ test('uploadOne(): failure (server error)', async () => {
 test('uploadOne(): failure (timeout)', async () => {
   const mockedRequest = request as jest.MockedFunction<typeof request>
 
-  const err = new UploadError('timeout')
-  err.code = UploadErrorCode.TIMEOUT
+  const err = new NetworkError('timeout')
+  err.code = NetworkErrorCode.TIMEOUT
 
   mockedRequest.mockRejectedValue(err)
 
@@ -711,7 +711,7 @@ test('uploadOne(): failure (timeout)', async () => {
     expect(mockedRequest).toHaveBeenCalledTimes(1)
   } catch (e) {
     expect(e).toBeTruthy()
-    expect((e as UploadError).code).toBe(UploadErrorCode.TIMEOUT)
+    expect((e as NetworkError).code).toBe(NetworkErrorCode.TIMEOUT)
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('The request timed out'), expect.any(Error))
   }
 })
@@ -1029,7 +1029,7 @@ test('uploadOne(): dispatches a request with the correct params with custom entr
 })
 
 test('uploadOne(): Fetch mode failure to get source map', async () => {
-  const err = new UploadError('misc upload error')
+  const err = new NetworkError('misc upload error')
   err.cause = new Error('network error')
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
@@ -1072,7 +1072,7 @@ test('uploadOne(): Fetch mode failure to get bundle', async () => {
   const directory = path.join(__dirname, 'fixtures/react-native-android')
   const sourceMap = await fs.readFile(path.resolve(directory, 'bundle.js.map'))
 
-  const err = new UploadError('misc upload error')
+  const err = new NetworkError('misc upload error')
   err.cause = new Error('network error')
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -739,6 +739,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
     retrieval: {
       type: SourceMapRetrievalType.Fetch,
       url: 'http://react-native-bundler:1234',
+      entryPoint: 'index.js',
     },
     version: {
       type: VersionType.AppVersion,
@@ -790,6 +791,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
     retrieval: {
       type: SourceMapRetrievalType.Fetch,
       url: 'http://react-native-bundler:1234',
+      entryPoint: 'index.js',
     },
     version: {
       type: VersionType.AppVersion,
@@ -841,6 +843,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
     retrieval: {
       type: SourceMapRetrievalType.Fetch,
       url: 'http://react-native-bundler:1234',
+      entryPoint: 'index.js',
     },
     version: {
       type: VersionType.AppVersion,
@@ -892,6 +895,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
     retrieval: {
       type: SourceMapRetrievalType.Fetch,
       url: 'http://react-native-bundler:1234',
+      entryPoint: 'index.js',
     },
     version: {
       type: VersionType.AppVersion,
@@ -911,6 +915,110 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
       apiKey: '123',
       overwrite: false,
       dev: true,
+      platform: 'ios',
+      appVersion: '1.2.3',
+      sourceMap: expect.any(File),
+      bundle: expect.any(File),
+    }),
+    expect.objectContaining({})
+  )
+})
+
+test('uploadOne(): dispatches a request with the correct params with custom entry point', async () => {
+  const directory = path.join(__dirname, 'fixtures/react-native-android')
+  const sourceMap = await fs.readFile(path.resolve(directory, 'bundle.js.map'))
+  const bundle = await fs.readFile(path.resolve(directory, 'bundle.js'))
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+  mockedFetch.mockResolvedValueOnce(sourceMap.toString())
+  mockedFetch.mockResolvedValueOnce(bundle.toString())
+
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  const uploader = new ReactNativeUploader(mockLogger)
+
+  await uploader.uploadOne({
+    endpoint: 'example.com',
+    apiKey: '123',
+    overwrite: false,
+    dev: false,
+    platformOptions: { type: Platform.Ios },
+    retrieval: {
+      type: SourceMapRetrievalType.Fetch,
+      url: 'http://react-native-bundler:1234',
+      entryPoint: 'cool-app.js',
+    },
+    version: {
+      type: VersionType.AppVersion,
+      appVersion: '1.2.3',
+    },
+    projectRoot: path.join(__dirname, 'fixtures/react-native-ios')
+  })
+
+  expect(mockedFetch).toHaveBeenCalledTimes(2)
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false')
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'example.com',
+    expect.objectContaining({
+      apiKey: '123',
+      overwrite: false,
+      dev: false,
+      platform: 'ios',
+      appVersion: '1.2.3',
+      sourceMap: expect.any(File),
+      bundle: expect.any(File),
+    }),
+    expect.objectContaining({})
+  )
+})
+
+test('uploadOne(): dispatches a request with the correct params with custom entry point with no ".js" extension', async () => {
+  const directory = path.join(__dirname, 'fixtures/react-native-android')
+  const sourceMap = await fs.readFile(path.resolve(directory, 'bundle.js.map'))
+  const bundle = await fs.readFile(path.resolve(directory, 'bundle.js'))
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+  mockedFetch.mockResolvedValueOnce(sourceMap.toString())
+  mockedFetch.mockResolvedValueOnce(bundle.toString())
+
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  const uploader = new ReactNativeUploader(mockLogger)
+
+  await uploader.uploadOne({
+    endpoint: 'example.com',
+    apiKey: '123',
+    overwrite: false,
+    dev: false,
+    platformOptions: { type: Platform.Ios },
+    retrieval: {
+      type: SourceMapRetrievalType.Fetch,
+      url: 'http://react-native-bundler:1234',
+      entryPoint: 'cool-app',
+    },
+    version: {
+      type: VersionType.AppVersion,
+      appVersion: '1.2.3',
+    },
+    projectRoot: path.join(__dirname, 'fixtures/react-native-ios')
+  })
+
+  expect(mockedFetch).toHaveBeenCalledTimes(2)
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false')
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'example.com',
+    expect.objectContaining({
+      apiKey: '123',
+      overwrite: false,
+      dev: false,
       platform: 'ios',
       appVersion: '1.2.3',
       sourceMap: expect.any(File),
@@ -942,6 +1050,7 @@ test('uploadOne(): Fetch mode failure to get source map', async () => {
       retrieval: {
         type: SourceMapRetrievalType.Fetch,
         url: 'http://react-native-bundler:1234',
+        entryPoint: 'index.js',
       },
       version: {
         type: VersionType.AppVersion,
@@ -985,6 +1094,7 @@ test('uploadOne(): Fetch mode failure to get bundle', async () => {
       retrieval: {
         type: SourceMapRetrievalType.Fetch,
         url: 'http://react-native-bundler:1234',
+        entryPoint: 'index.js',
       },
       version: {
         type: VersionType.AppVersion,

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -1028,9 +1028,8 @@ test('uploadOne(): dispatches a request with the correct params with custom entr
   )
 })
 
-test('uploadOne(): Fetch mode failure to get source map', async () => {
-  const err = new NetworkError('misc upload error')
-  err.cause = new Error('network error')
+test('uploadOne(): Fetch mode failure to get source map (generic Error)', async () => {
+  const err = new Error('misc error')
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
   mockedFetch.mockRejectedValue(err)
@@ -1063,17 +1062,183 @@ test('uploadOne(): Fetch mode failure to get source map', async () => {
     expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      'Unable to fetch source map from http://react-native-bundler:1234. Is the server running?'
+      expect.stringContaining('An unexpected error occurred'),
+      err
     )
   }
 })
 
-test('uploadOne(): Fetch mode failure to get bundle', async () => {
+test('uploadOne(): Fetch mode failure to get source map (generic NetworkError)', async () => {
+  const err = new NetworkError('misc error')
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+  mockedFetch.mockRejectedValue(err)
+
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  const uploader = new ReactNativeUploader(mockLogger)
+
+  try {
+    await uploader.uploadOne({
+      endpoint: 'example.com',
+      apiKey: '123',
+      overwrite: false,
+      dev: true,
+      platformOptions: { type: Platform.Android },
+      retrieval: {
+        type: SourceMapRetrievalType.Fetch,
+        url: 'http://react-native-bundler:1234',
+        entryPoint: 'index.js',
+      },
+      version: {
+        type: VersionType.AppVersion,
+        appVersion: '1.2.3',
+      },
+      projectRoot: path.join(__dirname, 'fixtures/react-native-android')
+    })
+  } catch (e) {
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedRequest).not.toHaveBeenCalled()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('An unexpected error occurred'),
+      err
+    )
+  }
+})
+
+test('uploadOne(): Fetch mode failure to get source map (connection refused)', async () => {
+  const err = new NetworkError('connection refused')
+  err.cause = new Error('network error')
+  err.code = NetworkErrorCode.CONNECTION_REFUSED
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+  mockedFetch.mockRejectedValue(err)
+
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  const uploader = new ReactNativeUploader(mockLogger)
+
+  try {
+    await uploader.uploadOne({
+      endpoint: 'example.com',
+      apiKey: '123',
+      overwrite: false,
+      dev: true,
+      platformOptions: { type: Platform.Android },
+      retrieval: {
+        type: SourceMapRetrievalType.Fetch,
+        url: 'http://react-native-bundler:1234',
+        entryPoint: 'index.js',
+      },
+      version: {
+        type: VersionType.AppVersion,
+        appVersion: '1.2.3',
+      },
+      projectRoot: path.join(__dirname, 'fixtures/react-native-android')
+    })
+  } catch (e) {
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedRequest).not.toHaveBeenCalled()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Unable to connect to http://react-native-bundler:1234. Is the server running?'),
+      err
+    )
+  }
+})
+
+test('uploadOne(): Fetch mode failure to get source map (server error)', async () => {
+  const err = new NetworkError('broken')
+  err.cause = new Error('network error')
+  err.code = NetworkErrorCode.SERVER_ERROR
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+  mockedFetch.mockRejectedValue(err)
+
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  const uploader = new ReactNativeUploader(mockLogger)
+
+  try {
+    await uploader.uploadOne({
+      endpoint: 'example.com',
+      apiKey: '123',
+      overwrite: false,
+      dev: true,
+      platformOptions: { type: Platform.Android },
+      retrieval: {
+        type: SourceMapRetrievalType.Fetch,
+        url: 'http://react-native-bundler:1234',
+        entryPoint: 'index.js',
+      },
+      version: {
+        type: VersionType.AppVersion,
+        appVersion: '1.2.3',
+      },
+      projectRoot: path.join(__dirname, 'fixtures/react-native-android')
+    })
+  } catch (e) {
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedRequest).not.toHaveBeenCalled()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining("Recieved an error from the server. Does the entry point file 'index.js' exist?"),
+      err
+    )
+  }
+})
+
+test('uploadOne(): Fetch mode failure to get source map (timeout)', async () => {
+  const err = new NetworkError('timeout')
+  err.cause = new Error('network error')
+  err.code = NetworkErrorCode.TIMEOUT
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+  mockedFetch.mockRejectedValue(err)
+
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  const uploader = new ReactNativeUploader(mockLogger)
+
+  try {
+    await uploader.uploadOne({
+      endpoint: 'example.com',
+      apiKey: '123',
+      overwrite: false,
+      dev: true,
+      platformOptions: { type: Platform.Android },
+      retrieval: {
+        type: SourceMapRetrievalType.Fetch,
+        url: 'http://react-native-bundler:1234',
+        entryPoint: 'index.js',
+      },
+      version: {
+        type: VersionType.AppVersion,
+        appVersion: '1.2.3',
+      },
+      projectRoot: path.join(__dirname, 'fixtures/react-native-android')
+    })
+  } catch (e) {
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedRequest).not.toHaveBeenCalled()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('The request timed out.'),
+      err
+    )
+  }
+})
+
+test('uploadOne(): Fetch mode failure to get bundle (generic Error)', async () => {
   const directory = path.join(__dirname, 'fixtures/react-native-android')
   const sourceMap = await fs.readFile(path.resolve(directory, 'bundle.js.map'))
 
-  const err = new NetworkError('misc upload error')
-  err.cause = new Error('network error')
+  const err = new Error('misc error')
 
   const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
   mockedFetch.mockResolvedValueOnce(sourceMap.toString())
@@ -1108,7 +1273,194 @@ test('uploadOne(): Fetch mode failure to get bundle', async () => {
     expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      'Unable to fetch bundle from http://react-native-bundler:1234. Is the server running?'
+      expect.stringContaining('An unexpected error occurred'),
+      err
+    )
+  }
+})
+
+test('uploadOne(): Fetch mode failure to get bundle (generic NetworkError)', async () => {
+  const directory = path.join(__dirname, 'fixtures/react-native-android')
+  const sourceMap = await fs.readFile(path.resolve(directory, 'bundle.js.map'))
+
+  const err = new NetworkError('misc error')
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+  mockedFetch.mockResolvedValueOnce(sourceMap.toString())
+  mockedFetch.mockRejectedValue(err)
+
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  const uploader = new ReactNativeUploader(mockLogger)
+
+  try {
+    await uploader.uploadOne({
+      endpoint: 'example.com',
+      apiKey: '123',
+      overwrite: false,
+      dev: true,
+      platformOptions: { type: Platform.Android },
+      retrieval: {
+        type: SourceMapRetrievalType.Fetch,
+        url: 'http://react-native-bundler:1234',
+        entryPoint: 'index.js',
+      },
+      version: {
+        type: VersionType.AppVersion,
+        appVersion: '1.2.3',
+      },
+      projectRoot: path.join(__dirname, 'fixtures/react-native-android')
+    })
+  } catch (e) {
+    expect(mockedFetch).toHaveBeenCalledTimes(2)
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedRequest).not.toHaveBeenCalled()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('An unexpected error occurred'),
+      err
+    )
+  }
+})
+
+test('uploadOne(): Fetch mode failure to get bundle (connection refused)', async () => {
+  const directory = path.join(__dirname, 'fixtures/react-native-android')
+  const sourceMap = await fs.readFile(path.resolve(directory, 'bundle.js.map'))
+
+  const err = new NetworkError('connection refused')
+  err.cause = new Error('network error')
+  err.code = NetworkErrorCode.CONNECTION_REFUSED
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+  mockedFetch.mockResolvedValueOnce(sourceMap.toString())
+  mockedFetch.mockRejectedValue(err)
+
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  const uploader = new ReactNativeUploader(mockLogger)
+
+  try {
+    await uploader.uploadOne({
+      endpoint: 'example.com',
+      apiKey: '123',
+      overwrite: false,
+      dev: true,
+      platformOptions: { type: Platform.Android },
+      retrieval: {
+        type: SourceMapRetrievalType.Fetch,
+        url: 'http://react-native-bundler:1234',
+        entryPoint: 'index.js',
+      },
+      version: {
+        type: VersionType.AppVersion,
+        appVersion: '1.2.3',
+      },
+      projectRoot: path.join(__dirname, 'fixtures/react-native-android')
+    })
+  } catch (e) {
+    expect(mockedFetch).toHaveBeenCalledTimes(2)
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedRequest).not.toHaveBeenCalled()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Unable to connect to http://react-native-bundler:1234. Is the server running?'),
+      err
+    )
+  }
+})
+
+test('uploadOne(): Fetch mode failure to get bundle (server error)', async () => {
+  const directory = path.join(__dirname, 'fixtures/react-native-android')
+  const sourceMap = await fs.readFile(path.resolve(directory, 'bundle.js.map'))
+
+  const err = new NetworkError('broken')
+  err.cause = new Error('network error')
+  err.code = NetworkErrorCode.SERVER_ERROR
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+  mockedFetch.mockResolvedValueOnce(sourceMap.toString())
+  mockedFetch.mockRejectedValue(err)
+
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  const uploader = new ReactNativeUploader(mockLogger)
+
+  try {
+    await uploader.uploadOne({
+      endpoint: 'example.com',
+      apiKey: '123',
+      overwrite: false,
+      dev: true,
+      platformOptions: { type: Platform.Android },
+      retrieval: {
+        type: SourceMapRetrievalType.Fetch,
+        url: 'http://react-native-bundler:1234',
+        entryPoint: 'index.js',
+      },
+      version: {
+        type: VersionType.AppVersion,
+        appVersion: '1.2.3',
+      },
+      projectRoot: path.join(__dirname, 'fixtures/react-native-android')
+    })
+  } catch (e) {
+    expect(mockedFetch).toHaveBeenCalledTimes(2)
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedRequest).not.toHaveBeenCalled()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining("Recieved an error from the server. Does the entry point file 'index.js' exist?"),
+      err
+    )
+  }
+})
+
+test('uploadOne(): Fetch mode failure to get bundle (timeout)', async () => {
+  const directory = path.join(__dirname, 'fixtures/react-native-android')
+  const sourceMap = await fs.readFile(path.resolve(directory, 'bundle.js.map'))
+
+  const err = new NetworkError('timeout')
+  err.cause = new Error('network error')
+  err.code = NetworkErrorCode.TIMEOUT
+
+  const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+  mockedFetch.mockResolvedValueOnce(sourceMap.toString())
+  mockedFetch.mockRejectedValue(err)
+
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  const uploader = new ReactNativeUploader(mockLogger)
+
+  try {
+    await uploader.uploadOne({
+      endpoint: 'example.com',
+      apiKey: '123',
+      overwrite: false,
+      dev: true,
+      platformOptions: { type: Platform.Android },
+      retrieval: {
+        type: SourceMapRetrievalType.Fetch,
+        url: 'http://react-native-bundler:1234',
+        entryPoint: 'index.js',
+      },
+      version: {
+        type: VersionType.AppVersion,
+        appVersion: '1.2.3',
+      },
+      projectRoot: path.join(__dirname, 'fixtures/react-native-android')
+    })
+  } catch (e) {
+    expect(mockedFetch).toHaveBeenCalledTimes(2)
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedRequest).not.toHaveBeenCalled()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('The request timed out.'),
+      err
     )
   }
 })


### PR DESCRIPTION
## Goal

This PR adds "fetch" mode to the `upload-react-native` command. Fetch mode communicates with the RN bundle server to generate the source map & bundle

This can be used by specifying `--fetch` and **not** specifying `--source-map`/`--bundle`. By default we expect the bundle server to run on `http://localhost:8081`, but `--url` can be used to customise this