### PR TITLE
Maze Runner tests for browser upload failure cases

### DIFF
--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -106,3 +106,186 @@ Feature: Browser source map upload multiple
     And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will be retried on a server failure (500 status code)
+    When I set the HTTP status code for the next request to 500
+    And I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --directory dist
+        --base-url "http://myapp.url/static/js/"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 4 requests
+    Then the exit code is successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    When I discard the oldest request
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    When I discard the oldest request
+    Then the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
+    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    When I discard the oldest request
+    Then the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
+    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will be retried up to 5 times on a server failure (500 status code)
+    When I set the HTTP status code to 500
+    And I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --directory dist
+        --base-url "http://myapp.url/static/js/"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 5 requests
+    Then the exit code is not successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    When I discard the oldest request
+    Then the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    When I discard the oldest request
+    Then the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    When I discard the oldest request
+    Then the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    When I discard the oldest request
+    Then the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will not be retried and further requests will not be made if the API key is invalid (401 status code)
+    When I set the HTTP status code for the next request to 401
+    And I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --directory dist
+        --base-url "http://myapp.url/static/js/"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 1 request
+    Then the exit code is not successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will not be retried and further requests will not be made if the source map is a duplicate (409 status code)
+    When I set the HTTP status code for the next request to 409
+    And I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --directory dist
+        --base-url "http://myapp.url/static/js/"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 1 request
+    Then the exit code is not successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will not be retried and further requests will not be made if the bundle or source map is empty (422 status code)
+    When I set the HTTP status code for the next request to 422
+    And I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --directory dist
+        --base-url "http://myapp.url/static/js/"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 1 request
+    Then the exit code is not successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will not be retried and further requests will not be made if request is bad (400 status code)
+    When I set the HTTP status code for the next request to 400
+    And I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --directory dist
+        --base-url "http://myapp.url/static/js/"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 1 request
+    Then the exit code is not successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+

--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -11,29 +11,21 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 3 requests
     Then the exit code is successful
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
+    And the Content-Type header is valid multipart form-data for all requests
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "appVersion" equals "2.0.0" for all requests
+    And the payload field "overwrite" is null for all requests
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
     And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
     When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
     And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
     When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
     And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
 
   Scenario: Auto detecting app version
     When I run the service "multiple-source-map-webpack" with the command
@@ -46,29 +38,21 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 3 requests
     Then the exit code is successful
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "4.5.6"
-    And the payload field "overwrite" is null
+    And the Content-Type header is valid multipart form-data for all requests
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "appVersion" equals "4.5.6" for all requests
+    And the payload field "overwrite" is null for all requests
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
     And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
     When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "4.5.6"
-    And the payload field "overwrite" is null
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
     And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
     When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "4.5.6"
-    And the payload field "overwrite" is null
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
     And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
 
   Scenario: Overwrite enabled
     When I run the service "multiple-source-map-webpack" with the command
@@ -83,29 +67,21 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 3 requests
     Then the exit code is successful
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
+    And the Content-Type header is valid multipart form-data for all requests
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "appVersion" equals "2.0.0" for all requests
+    And the payload field "overwrite" equals "true" for all requests
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
     And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
     When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
     And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
     When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
     And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
 
   Scenario: A request will be retried on a server failure (500 status code)
     When I set the HTTP status code for the next request to 500
@@ -120,37 +96,25 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 4 requests
     Then the exit code is successful
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
+    And the Content-Type header is valid multipart form-data for all requests
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "appVersion" equals "2.0.0" for all requests
+    And the payload field "overwrite" is null for all requests
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
     And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
     When I discard the oldest request
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
     And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
     When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
     And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
     When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
     And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
 
   Scenario: A request will be retried up to 5 times on a server failure (500 status code)
     When I set the HTTP status code to 500
@@ -165,47 +129,15 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 5 requests
     Then the exit code is not successful
+    And the Content-Type header is valid multipart form-data for all requests
     And the shell has output "A server side error occurred while processing the upload." to stdout
     And the shell has output "HTTP status 500 received from upload API" to stdout
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
-    When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
-    When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
-    When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
-    When I discard the oldest request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "appVersion" equals "2.0.0" for all requests
+    And the payload field "overwrite" is null for all requests
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js" for all requests
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack" for all requests
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack" for all requests
 
   Scenario: A request will not be retried and further requests will not be made if the API key is invalid (401 status code)
     When I set the HTTP status code for the next request to 401

--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -165,6 +165,8 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 5 requests
     Then the exit code is not successful
+    And the shell has output "A server side error occurred while processing the upload." to stdout
+    And the shell has output "HTTP status 500 received from upload API" to stdout
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -218,6 +220,8 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
+    And the shell has output "The provided API key was invalid." to stdout
+    And the shell has output "HTTP status 401 received from upload API" to stdout
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -239,6 +243,8 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
+    And the shell has output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag." to stdout
+    And the shell has output "HTTP status 409 received from upload API" to stdout
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -260,6 +266,8 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
+    And the shell has output "The uploaded source map was empty." to stdout
+    And the shell has output "HTTP status 422 received from upload API" to stdout
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -281,6 +289,8 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
+    And the shell has output "The request was rejected by the server as invalid." to stdout
+    And the shell has output "HTTP status 400 received from upload API" to stdout
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -288,4 +298,3 @@ Feature: Browser source map upload multiple
     And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
-

--- a/features/browser-upload-one.feature
+++ b/features/browser-upload-one.feature
@@ -61,3 +61,173 @@ Feature: Browser source map upload one
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
     And the exit code is successful
+
+  Scenario: A request will be retried on a server failure (500 status code)
+    When I set the HTTP status code for the next request to 500
+    And I run the service "single-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --source-map dist/main.js.map
+        --bundle dist/main.js
+        --bundle-url "http://myapp.url/static/js/main.js"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 2 requests
+    Then the exit code is successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    And I discard the oldest request
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will be retried up to 5 times on a server failure (500 status code)
+    When I set the HTTP status code to 500
+    And I run the service "single-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --source-map dist/main.js.map
+        --bundle dist/main.js
+        --bundle-url "http://myapp.url/static/js/main.js"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 5 requests
+    Then the exit code is not successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    And I discard the oldest request
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    And I discard the oldest request
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will not be retried if the API key is invalid (401 status code)
+    When I set the HTTP status code for the next request to 401
+    And I run the service "single-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --source-map dist/main.js.map
+        --bundle dist/main.js
+        --bundle-url "http://myapp.url/static/js/main.js"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 1 request
+    Then the exit code is not successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will not be retried if the source map is a duplicate (409 status code)
+    When I set the HTTP status code for the next request to 409
+    And I run the service "single-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --source-map dist/main.js.map
+        --bundle dist/main.js
+        --bundle-url "http://myapp.url/static/js/main.js"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 1 request
+    Then the exit code is not successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will not be retried if the bundle or source map is empty (422 status code)
+    When I set the HTTP status code for the next request to 422
+    And I run the service "single-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --source-map dist/main.js.map
+        --bundle dist/main.js
+        --bundle-url "http://myapp.url/static/js/main.js"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 1 request
+    Then the exit code is not successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+
+  Scenario: A request will not be retried if request is bad (400 status code)
+    When I set the HTTP status code for the next request to 400
+    And I run the service "single-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --source-map dist/main.js.map
+        --bundle dist/main.js
+        --bundle-url "http://myapp.url/static/js/main.js"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 1 request
+    Then the exit code is not successful
+    And the payload field "apiKey" equals "123"
+    And the payload field "appVersion" equals "2.0.0"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data

--- a/features/browser-upload-one.feature
+++ b/features/browser-upload-one.feature
@@ -76,21 +76,17 @@ Feature: Browser source map upload one
       """
     And I wait to receive 2 requests
     Then the exit code is successful
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
+    And the Content-Type header is valid multipart form-data for all requests
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "appVersion" equals "2.0.0" for all requests
+    And the payload field "overwrite" is null for all requests
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
     And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
     And I discard the oldest request
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
     And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
     And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
 
   Scenario: A request will be retried up to 5 times on a server failure (500 status code)
     When I set the HTTP status code to 500
@@ -108,43 +104,13 @@ Feature: Browser source map upload one
     Then the exit code is not successful
     And the shell has output "A server side error occurred while processing the upload." to stdout
     And the shell has output "HTTP status 500 received from upload API" to stdout
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
-    And I discard the oldest request
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
-    And I discard the oldest request
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
-    And the Content-Type header is valid multipart form-data
+    And the Content-Type header is valid multipart form-data for all requests
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "appVersion" equals "2.0.0" for all requests
+    And the payload field "overwrite" is null for all requests
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js" for all requests
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack" for all requests
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack" for all requests
 
   Scenario: A request will not be retried if the API key is invalid (401 status code)
     When I set the HTTP status code for the next request to 401

--- a/features/browser-upload-one.feature
+++ b/features/browser-upload-one.feature
@@ -106,6 +106,8 @@ Feature: Browser source map upload one
       """
     And I wait to receive 5 requests
     Then the exit code is not successful
+    And the shell has output "A server side error occurred while processing the upload." to stdout
+    And the shell has output "HTTP status 500 received from upload API" to stdout
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -158,6 +160,8 @@ Feature: Browser source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
+    And the shell has output "The provided API key was invalid." to stdout
+    And the shell has output "HTTP status 401 received from upload API" to stdout
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -180,6 +184,8 @@ Feature: Browser source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
+    And the shell has output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag." to stdout
+    And the shell has output "HTTP status 409 received from upload API" to stdout
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -202,6 +208,8 @@ Feature: Browser source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
+    And the shell has output "The uploaded source map was empty." to stdout
+    And the shell has output "HTTP status 422 received from upload API" to stdout
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -224,6 +232,8 @@ Feature: Browser source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
+    And the shell has output "The request was rejected by the server as invalid." to stdout
+    And the shell has output "HTTP status 400 received from upload API" to stdout
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -75,3 +75,14 @@ Then("the exit code is not successful") do
     "Expected the last command to exit unsuccessfully, but it exited with code 0"
   )
 end
+
+Then('the shell has output {string} to stdout') do |expected_line|
+  assert(
+    Docker.output.any? { |line| line.include?(expected_line) },
+    <<~TEXT
+      No line of output included '#{expected_line}'.
+      Full output:
+      #{Docker.output.join("")}
+    TEXT
+  )
+end

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -67,3 +67,11 @@ Then("the exit code is successful") do
     "Expected the last command to exit successfully, but it exited with code #{Docker.last_exit_code}"
   )
 end
+
+Then("the exit code is not successful") do
+  assert_not_equal(
+    Docker.last_exit_code,
+    0,
+    "Expected the last command to exit unsuccessfully, but it exited with code 0"
+  )
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -25,12 +25,13 @@ Before do
   # don't run commands themselves. In which case, why would they care about the
   # last exit code??
   module RecordExitCode
+    attr_reader :output
     attr_reader :last_exit_code
 
     def run_docker_compose_command(...)
       raise "You can't use RecordExitCode without a super class!" unless defined?(super)
 
-      _output, @last_exit_code = super(...)
+      @output, @last_exit_code = super(...)
     end
   end
 


### PR DESCRIPTION
Tests for various failure cases for single & multiple upload:

- A request will be retried on a server failure (500 status code)
- A request will be retried up to 5 times on a server failure (500 status code)
- A request will not be retried and further requests will not be made if the API key is invalid (401 status code)
- A request will not be retried and further requests will not be made if the source map is a duplicate (409 status code)
- A request will not be retried and further requests will not be made if the bundle or source map is empty (422 status code)
- A request will not be retried and further requests will not be made if request is bad (400 status code)