### PR TITLE
[PLAT-5092] Facilitate webpack-bugsnag-plugins support

### DIFF
--- a/src/Request.ts
+++ b/src/Request.ts
@@ -16,6 +16,7 @@ interface JsPayload {
   type: PayloadType.Node | PayloadType.Browser
   apiKey: string
   appVersion?: string
+  codeBundleId?: string
   minifiedUrl: string
   sourceMap: File
   minifiedFile?: File
@@ -73,6 +74,7 @@ function createFormData (payload: Payload): FormData {
 
 function appendJsFormData(formData: FormData, payload: BrowserPayload | NodePayload): FormData {
   if (payload.appVersion) formData.append('appVersion', payload.appVersion)
+  if (payload.codeBundleId) formData.append('codeBundleId', payload.codeBundleId)
   formData.append('minifiedUrl', payload.minifiedUrl)
   formData.append('sourceMap', payload.sourceMap.data, { filepath: payload.sourceMap.filepath})
   if (payload.minifiedFile) formData.append('minifiedFile', payload.minifiedFile.data, { filepath: payload.minifiedFile.filepath})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export * as browser from './uploaders/BrowserUploader'
+export * as node from './uploaders/NodeUploader'
+export * as reactNative from './uploaders/ReactNativeUploader'

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -17,6 +17,7 @@ interface UploadSingleOpts {
   bundleUrl: string
   bundle?: string
   appVersion?: string
+  codeBundleId?: string
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
@@ -30,6 +31,7 @@ export async function uploadOne ({
   bundle,
   sourceMap,
   appVersion,
+  codeBundleId,
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = 'https://upload.bugsnag.com/',
@@ -59,7 +61,8 @@ export async function uploadOne ({
     await request(endpoint, {
       type: PayloadType.Browser,
       apiKey,
-      appVersion,
+      appVersion: codeBundleId ? undefined : appVersion,
+      codeBundleId,
       minifiedUrl: bundleUrl,
       minifiedFile: (bundleContent && fullBundlePath) ? { filepath: fullBundlePath, data: bundleContent } : undefined,
       sourceMap: { filepath: fullSourceMapPath, data: JSON.stringify(transformedSourceMap) },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "exclude": [
-    "**/__test__/**",
-    "features"
+    "**/__test__/**"
   ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "exclude": [
-    "__test__",
+    "**/__test__/**",
     "features"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "skipLibCheck": false,
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": [
-    "features"
+  "include": [
+    "src/**/*"
   ]
 }


### PR DESCRIPTION
## Goal

When updating webpack-bugsnag-plugins, I needed some changes to maintain feature parity.

1. exporting the programmatic interfaces at the top level, for convenience
2. allow `codeBundleId` to be set in the browser payload

## Design

This seemed like the least invasive way to allow the `webpack-bugsnag-plugins` to facilitate NativeScript as it currently does.

## Changeset

Allows `codeBundleId` in the browser payload (via programmatic interface, not via cli).
Exports the `uploaders` modules at the top level for convenient programmatic usage.

Also noticed compiled test files when included as a `node_module`, so updated the exclude property in `tsconfig.json`.

## Testing

Unit tests continue to pass on this repo. Tests on webpack-bugsnag-plugins assert that the change works.