### PR TITLE
Fix RN command always requiring appVersion

### DIFF
--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -221,6 +221,27 @@ test('cli: upload-react-native success (ios with app bundle version)', async () 
     'upload-react-native',
     '--api-key', '1234',
     '--platform', 'ios',
+    '--app-bundle-version', '1.2.3',
+    '--source-map', 'some/file.js.map',
+    '--bundle', 'some/file.js',
+  ])
+
+  expect(reactNative.uploadOne).toHaveBeenCalledWith(expect.objectContaining({
+    apiKey: '1234',
+    platform: 'ios',
+    appBundleVersion: '1.2.3',
+    bundle: 'some/file.js',
+    sourceMap: 'some/file.js.map',
+  }))
+
+  expect(process.exitCode).toBe(0)
+})
+
+test('cli: upload-react-native success (ios with app bundle version and app version)', async () => {
+  await run([
+    'upload-react-native',
+    '--api-key', '1234',
+    '--platform', 'ios',
     '--app-version', '1.0.2',
     '--app-bundle-version', '1.2.3',
     '--source-map', 'some/file.js.map',
@@ -261,6 +282,27 @@ test('cli: upload-react-native success (android)', async () => {
 })
 
 test('cli: upload-react-native success (android with app version code)', async () => {
+  await run([
+    'upload-react-native',
+    '--api-key', '1234',
+    '--platform', 'android',
+    '--app-version-code', '1.2.3',
+    '--source-map', 'some/file.js.map',
+    '--bundle', 'some/file.js',
+  ])
+
+  expect(reactNative.uploadOne).toHaveBeenCalledWith(expect.objectContaining({
+    apiKey: '1234',
+    platform: 'android',
+    appVersionCode: '1.2.3',
+    bundle: 'some/file.js',
+    sourceMap: 'some/file.js.map',
+  }))
+
+  expect(process.exitCode).toBe(0)
+})
+
+test('cli: upload-react-native success (android with app version code and app version)', async () => {
   await run([
     'upload-react-native',
     '--api-key', '1234',
@@ -548,7 +590,7 @@ test('cli: upload-react-native fails with code bundle id and app version code', 
   expect(process.exitCode).toBe(1)
 })
 
-test('cli: upload-react-native fails without app version or code bundle id', async () => {
+test('cli: upload-react-native fails without any version given', async () => {
   await run([
     'upload-react-native',
     '--api-key', '1234',
@@ -559,7 +601,7 @@ test('cli: upload-react-native fails without app version or code bundle id', asy
 
   expect(reactNative.uploadOne).not.toHaveBeenCalled()
   expect(reactNative.fetchAndUploadOne).not.toHaveBeenCalled()
-  expect(logger.error).toHaveBeenCalledWith('Either --app-version or --code-bundle-id must be given')
+  expect(logger.error).toHaveBeenCalledWith('--code-bundle-id or at least one of --app-version, --app-version-code and --app-bundle-version must be given')
   expect(process.exitCode).toBe(1)
 })
 

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -187,18 +187,14 @@ function validatePlatform(opts: Record<string, unknown>): void {
   if (opts.platform !== 'ios' && opts.platform !== 'android') {
     throw new Error('--platform must be either "android" or "ios"')
   }
-
 }
 
 function validateVersion(opts: Record<string, unknown>): void {
-  if (opts.appVersion) {
-    if (opts.codeBundleId) {
+  if (opts.codeBundleId) {
+    if (opts.appVersion) {
       throw new Error('--app-version and --code-bundle-id cannot both be given')
     }
-    return
-  }
 
-  if (opts.codeBundleId) {
     if (opts.appBundleVersion) {
       throw new Error('--app-bundle-version and --code-bundle-id cannot both be given')
     }
@@ -210,7 +206,9 @@ function validateVersion(opts: Record<string, unknown>): void {
     return
   }
 
-  throw new Error('Either --app-version or --code-bundle-id must be given')
+  if (!opts.appVersion && !opts.appVersionCode && !opts.appBundleVersion) {
+    throw new Error('--code-bundle-id or at least one of --app-version, --app-version-code and --app-bundle-version must be given')
+  }
 }
 
 function validatePlatformOptions(opts: Record<string, unknown>): void {


### PR DESCRIPTION
## Goal

If `appVersion` is not given, it's OK so long as `appVersionCode` or `appBundleVersion` is supplied instead

As before, giving both `codeBundleId` and another version type is an error, as is not giving any version type at all