### PR TITLE
docs(readme): add top-level license file link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Most updates to this repo will be made by Bugsnag employees. We are unable to ac
 
 ## License
 
-MIT
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.


### PR DESCRIPTION
## Goal

Adding the standard license file link.