### PR TITLE
[PLAT-5479] Use `/source-maps` endpoint for browser and node source maps

### DIFF
--- a/src/Request.ts
+++ b/src/Request.ts
@@ -123,7 +123,7 @@ export async function send (endpoint: string, payload: Payload, requestOpts: htt
       agent: requestOpts && requestOpts.agent
     }, res => {
       res.pipe(concat((bodyBuffer: Buffer) => {
-        if (res.statusCode === 200) return resolve()
+        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) return resolve()
         const err = new NetworkError(`HTTP status ${res.statusCode} received from upload API`)
         err.responseText = bodyBuffer.toString()
         if (!isRetryable(res.statusCode)) {

--- a/src/__test__/Request.test.ts
+++ b/src/__test__/Request.test.ts
@@ -69,6 +69,7 @@ test('request: send() successful React Native upload', async () => {
       const form = new multiparty.Form()
       form.parse(req, function(err, fields, files) {
         received.push({ fields, files })
+        res.statusCode = 202
         res.end('OK')
         resolve()
       });

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -12,6 +12,8 @@ import readSourceMap from './lib/ReadSourceMap'
 import parseSourceMap from './lib/ParseSourceMap'
 import detectAppVersion from './lib/DetectAppVersion'
 
+const UPLOAD_ENDPOINT = 'https://upload.bugsnag.com/source-map'
+
 interface UploadSingleOpts {
   apiKey: string
   sourceMap: string
@@ -35,7 +37,7 @@ export async function uploadOne ({
   codeBundleId,
   overwrite = false,
   projectRoot = process.cwd(),
-  endpoint = 'https://upload.bugsnag.com/',
+  endpoint = UPLOAD_ENDPOINT,
   requestOpts = {},
   logger = noopLogger
 }: UploadSingleOpts): Promise<void> {
@@ -99,7 +101,7 @@ export async function uploadMultiple ({
   appVersion,
   overwrite = false,
   projectRoot = process.cwd(),
-  endpoint = 'https://upload.bugsnag.com/',
+  endpoint = UPLOAD_ENDPOINT,
   requestOpts = {},
   logger = noopLogger
 }: UploadMultipleOpts): Promise<void> {

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -12,6 +12,8 @@ import readSourceMap from './lib/ReadSourceMap'
 import parseSourceMap from './lib/ParseSourceMap'
 import detectAppVersion from './lib/DetectAppVersion'
 
+const UPLOAD_ENDPOINT = 'https://upload.bugsnag.com/source-map'
+
 interface UploadSingleOpts {
   apiKey: string
   sourceMap: string
@@ -31,7 +33,7 @@ export async function uploadOne ({
   appVersion,
   overwrite = false,
   projectRoot = process.cwd(),
-  endpoint = 'https://upload.bugsnag.com/',
+  endpoint = UPLOAD_ENDPOINT,
   requestOpts = {},
   logger = noopLogger
 }: UploadSingleOpts): Promise<void> {
@@ -87,7 +89,7 @@ export async function uploadMultiple ({
   appVersion,
   overwrite = false,
   projectRoot = process.cwd(),
-  endpoint = 'https://upload.bugsnag.com/',
+  endpoint = UPLOAD_ENDPOINT,
   requestOpts = {},
   logger = noopLogger
 }: UploadMultipleOpts): Promise<void> {

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -29,7 +29,7 @@ test('uploadOne(): dispatches a request with the correct params', async () => {
   })
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/',
+    'https://upload.bugsnag.com/source-map',
     expect.objectContaining({
       apiKey: '123',
       appVersion: '1.2.3',
@@ -54,7 +54,7 @@ test('uploadOne(): dispatches a request with the correct params (no bundle)', as
   })
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/',
+    'https://upload.bugsnag.com/source-map',
     expect.objectContaining({
       apiKey: '123',
       appVersion: '1.2.3',
@@ -294,7 +294,7 @@ test('uploadMultiple(): success', async () => {
   })
   expect(mockedRequest).toHaveBeenCalledTimes(4)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/',
+    'https://upload.bugsnag.com/source-map',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -312,7 +312,7 @@ test('uploadMultiple(): success', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/',
+    'https://upload.bugsnag.com/source-map',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -330,7 +330,7 @@ test('uploadMultiple(): success', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/',
+    'https://upload.bugsnag.com/source-map',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -348,7 +348,7 @@ test('uploadMultiple(): success', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/',
+    'https://upload.bugsnag.com/source-map',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({

--- a/src/uploaders/__test__/NodeUploader.test.ts
+++ b/src/uploaders/__test__/NodeUploader.test.ts
@@ -28,7 +28,7 @@ test('uploadOne(): dispatches a request with the correct params', async () => {
   })
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/',
+    'https://upload.bugsnag.com/source-map',
     expect.objectContaining({
       apiKey: '123',
       appVersion: '1.2.3',
@@ -131,7 +131,7 @@ test('uploadMultiple(): success', async () => {
   })
   expect(mockedRequest).toHaveBeenCalledTimes(3)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/',
+    'https://upload.bugsnag.com/source-map',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -149,7 +149,7 @@ test('uploadMultiple(): success', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/',
+    'https://upload.bugsnag.com/source-map',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -167,7 +167,7 @@ test('uploadMultiple(): success', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/',
+    'https://upload.bugsnag.com/source-map',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({


### PR DESCRIPTION
## Goal

Use the `/source-maps` endpoint for better server-side routing and diagnostics.

## Design

Previously everything went to the root path of the upload server, which meant that the entire payload has to be read before applying any validation or inspection of the request. The pipeline team have now provided separate endpoints for the different source map types and we already use `/react-native-source-map` for RN payloads.

## Changeset

Updated Node and Browser to use the `/source-map` route. This route responds with a `202 Accepted` response when the upload succeeds, so the HTTP status code logic needed updating to treat any 20X status code as a success.

## Testing

Covered by existing tests.