### PR TITLE
Allow absolute paths in the `--directory` option

### DIFF
--- a/.jest/setup.js
+++ b/.jest/setup.js
@@ -1,2 +1,2 @@
 process.env.BUGSNAG_RETRY_INTERVAL_MS = '10'
-process.env.BUGSNAG_TIMEOUT_MS = '100'
+process.env.BUGSNAG_TIMEOUT_MS = '250'

--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -27,6 +27,34 @@ Feature: Browser source map upload multiple
     And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
+  Scenario: Basic success case (webpack) with absolute path --directory
+    When I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --directory /app/dist
+        --base-url "http://myapp.url/static/js/"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 3 requests
+    Then the exit code is successful
+    And the Content-Type header is valid multipart form-data for all requests
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "appVersion" equals "2.0.0" for all requests
+    And the payload field "overwrite" is null for all requests
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest request
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
+    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest request
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
+    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+
   Scenario: Basic success case (babel)
     When I run the service "multiple-source-map-babel-browser" with the command
       """

--- a/features/node-upload-multiple.feature
+++ b/features/node-upload-multiple.feature
@@ -26,6 +26,33 @@ Feature: Node source map upload multiple
     And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
+  Scenario: Basic success case (webpack) with absolute path --directory
+    When I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-node
+        --api-key 123
+        --app-version 2.0.0
+        --directory /app/dist
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 3 requests
+    Then the exit code is successful
+    And the Content-Type header is valid multipart form-data for all requests
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "appVersion" equals "2.0.0" for all requests
+    And the payload field "overwrite" is null for all requests
+    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest request
+    And the payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
+    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest request
+    And the payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
+    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+
   Scenario: Basic success case (babel)
     When I run the service "multiple-source-map-babel-node" with the command
       """

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -105,7 +105,7 @@ export async function uploadMultiple ({
 }: UploadMultipleOpts): Promise<void> {
   logger.info(`Uploading browser source maps for "${baseUrl}"`)
   logger.debug(`Searching for source maps "${directory}"`)
-  const absoluteSearchPath = path.join(projectRoot, directory)
+  const absoluteSearchPath = path.resolve(projectRoot, directory)
   const sourceMaps: string[] = await new Promise((resolve, reject) => {
     glob('**/*.map', { ignore: '**/*.css.map', cwd: absoluteSearchPath }, (err, files) => {
       if (err) return reject(err)

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -93,7 +93,7 @@ export async function uploadMultiple ({
 }: UploadMultipleOpts): Promise<void> {
   logger.info(`Uploading node source maps for "${directory}"`)
   logger.debug(`Searching for source maps "${directory}"`)
-  const absoluteSearchPath = path.join(projectRoot, directory)
+  const absoluteSearchPath = path.resolve(projectRoot, directory)
   const sourceMaps: string[] = await new Promise((resolve, reject) => {
     glob('**/*.map', { ignore: '**/node_modules/**', cwd: absoluteSearchPath }, (err, files) => {
       if (err) return reject(err)

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -367,6 +367,92 @@ test('uploadMultiple(): success', async () => {
   )
 })
 
+test('uploadMultiple(): success using absolute path for "directory"', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadMultiple({
+    apiKey: '123',
+    baseUrl: 'http://mybundle.jim/',
+    directory: path.join(__dirname, 'fixtures/c/build'),
+    projectRoot: path.join(__dirname, 'fixtures/c'),
+    logger: mockLogger
+  })
+
+  expect(mockedRequest).toHaveBeenCalledTimes(4)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/2.e5bb21a6.chunk.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/2.e5bb21a6.chunk.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'http://mybundle.jim/static/js/2.e5bb21a6.chunk.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/3.1b8b4fc7.chunk.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/3.1b8b4fc7.chunk.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'http://mybundle.jim/static/js/3.1b8b4fc7.chunk.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/main.286ac573.chunk.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/main.286ac573.chunk.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'http://mybundle.jim/static/js/main.286ac573.chunk.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/runtime-main.ad66c902.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/runtime-main.ad66c902.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'http://mybundle.jim/static/js/runtime-main.ad66c902.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+})
+
 test('uploadMultiple(): no source maps', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
   const err = new NetworkError('timeout')

--- a/src/uploaders/__test__/NodeUploader.test.ts
+++ b/src/uploaders/__test__/NodeUploader.test.ts
@@ -186,6 +186,73 @@ test('uploadMultiple(): success', async () => {
   )
 })
 
+test('uploadMultiple(): success using absolute path for "directory"', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadMultiple({
+    apiKey: '123',
+    directory: path.join(__dirname, 'fixtures/f/dist'),
+    projectRoot: path.join(__dirname, 'fixtures/f'),
+    logger: mockLogger,
+    appVersion: '1.2.3'
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(3)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/f/dist/a.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/f/dist/a.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'dist/a.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/f/dist/b.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/f/dist/b.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'dist/b.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/f/dist/index.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/f/dist/index.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'dist/index.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+})
+
 test('uploadMultiple(): no source maps', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
   const err = new NetworkError('timeout')


### PR DESCRIPTION
## Goal

The intention of `--directory` was to be a path to a directory _within the project root_, but this is a bit unclear. Using an absolute path doesn't work because the directory and project root are concatenated, which will never result in a valid path

This now uses `path.resolve` to ensure that an absolute `--directory` will be used as-is

The request unit tests were flaking on CI ([example](https://github.com/bugsnag/bugsnag-source-maps/runs/1492421430?check_suite_focus=true)) so I increased the timeout from 100ms to 250ms

## Testing

Unit tested by duplicating the relative path `--directory` tests but switching them to absolute paths and added MR tests