### PR TITLE
Change 'file' to 'filepath' in help

### DIFF
--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -92,7 +92,7 @@ const browserCommandSingleDefs = [
     name: 'source-map',
     type: String,
     description: 'the path to the source map {bold required}',
-    typeLabel: '{underline file}'
+    typeLabel: '{underline filepath}'
   },
   {
     name: 'bundle-url',
@@ -104,7 +104,7 @@ const browserCommandSingleDefs = [
     name: 'bundle',
     type: String,
     description: 'the path to the bundle',
-    typeLabel: '{underline file}'
+    typeLabel: '{underline filepath}'
   },
 ]
 const browserCommandMultipleDefs = [

--- a/src/commands/UploadNodeCommand.ts
+++ b/src/commands/UploadNodeCommand.ts
@@ -90,13 +90,13 @@ const nodeCommandSingleDefs = [
     name: 'source-map',
     type: String,
     description: 'the path to the source map {bold required}',
-    typeLabel: '{underline file}'
+    typeLabel: '{underline filepath}'
   },
   {
     name: 'bundle',
     type: String,
     description: 'the path to the bundle {bold required}',
-    typeLabel: '{underline file}'
+    typeLabel: '{underline filepath}'
   }
 ]
 const nodeCommandMultipleDefs = [

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -138,13 +138,13 @@ const reactNativeProvideOpts = [
     name: 'source-map',
     type: String,
     description: 'the path to the source map {bold required}',
-    typeLabel: '{underline file}',
+    typeLabel: '{underline filepath}',
   },
   {
     name: 'bundle',
     type: String,
     description: 'the path to the bundle {bold required}',
-    typeLabel: '{underline file}',
+    typeLabel: '{underline filepath}',
   },
 ]
 
@@ -164,7 +164,7 @@ const reactNativeFetchOpts = [
     name: 'bundler-entry-point',
     type: String,
     description: 'the entry point of your React Native app',
-    typeLabel: '{underline file}',
+    typeLabel: '{underline filepath}',
   },
 ]
 


### PR DESCRIPTION
## Goal

Change arguments with a type of `file` to `filepath`, which is a bit clearer

<details>
<summary>Browser help</summary>

```
$ ./bin/cli upload-browser --help

  bugsnag-source-maps upload-browser [...opts] 

Options

  --api-key string        your project's API key required                                       
  --overwrite             whether to replace exiting source maps uploaded with the same version 
  --project-root string   the top level directory of your project                               
  --endpoint string       customize the endpoint for Bugsnag On-Premise                         
  --quiet                 less verbose logging                                                  
  --app-version string                                                                          

Single upload

  Options for uploading a source map for a single bundle 

  --source-map filepath   the path to the source map required                                
  --bundle-url url        the URL the bundle is served at (may contain * wildcards) required 
  --bundle filepath       the path to the bundle                                             

Multiple upload

  Options for recursing directory and upload multiple source maps 

  --directory path   the directory to start searching for source maps in required                  
  --base-url url     the base URL that JS bundles are served from (may contain * wildcards)        
                     required                                                                      
```
</details>

<details>
<summary>Node help</summary>

```
$ ./bin/cli upload-node --help

  bugsnag-source-maps upload-node [...opts] 

Options

  --api-key string        your project's API key required                                       
  --overwrite             whether to replace exiting source maps uploaded with the same version 
  --project-root string   the top level directory of your project                               
  --endpoint string       customize the endpoint for Bugsnag On-Premise                         
  --quiet                 less verbose logging                                                  
  --app-version string                                                                          

Single upload

  Options for uploading a source map for a single bundle 

  --source-map filepath   the path to the source map required 
  --bundle filepath       the path to the bundle required     

Multiple upload

  Options for recursing directory and upload multiple source maps 

  --directory path   the directory to start searching for source maps in required 
```
</details>

<details>
<summary>ReactNative help</summary>

```
$ ./bin/cli upload-react-native --help

  bugsnag-source-maps upload-react-native [...opts] 

Options

  --api-key string              your project's API key required                                       
  --overwrite                   whether to replace exiting source maps uploaded with the same version 
  --project-root string         the top level directory of your project                               
  --endpoint string             customize the endpoint for Bugsnag On-Premise                         
  --quiet                       less verbose logging                                                  
  --platform string             the application platform, either "android" or "ios" required          
  --app-version string                                                                                
  --code-bundle-id string                                                                             
  --app-version-code string                                                                           
  --app-bundle-version string                                                                         
  --dev                         indicates this is a debug build                                       

Provide souce map and bundle

  Options for uploading a source map and bundle 

  --source-map filepath   the path to the source map required 
  --bundle filepath       the path to the bundle required     

Fetch source map and bundle

  Options for fetching a source map and bundle from the React Native bundler 

  --fetch                          enable fetch mode required                
  --bundler-url url                the URL of the React Native bundle server 
  --bundler-entry-point filepath   the entry point of your React Native app  
```
</details>