### PR TITLE
Add extra info when a value with a wildcard might not be in quotes

### DIFF
--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -28,7 +28,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
       const wildcardArgument = argv.find(arg => arg === '--bundle-url' || arg === '--base-url')
 
       if (wildcardArgument) {
-        logger.info(`Values that contain a wildcard must be wrapped in quotes, for example ${wildcardArgument} "*"`)
+        logger.info(`Values that contain a wildcard must be wrapped in quotes to prevent shell expansion, for example ${wildcardArgument} "*"`)
       }
     } else {
       logger.error(e.message)

--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -22,6 +22,14 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
     process.exitCode = 1
     if (e.name === 'UNKNOWN_VALUE') {
       logger.error(`Invalid argument provided. ${e.message}`)
+
+      // Check if the user provided an argument that allows a wildcard ('*') and
+      // if so, warn them about wrapping the value in quotes
+      const wildcardArgument = argv.find(arg => arg === '--bundle-url' || arg === '--base-url')
+
+      if (wildcardArgument) {
+        logger.info(`Values that contain a wildcard must be wrapped in quotes, for example ${wildcardArgument} "*"`)
+      }
     } else {
       logger.error(e.message)
     }


### PR DESCRIPTION
## Goal

This PR adds an info message when an argument that allows a wildcard is used and we encounter an unknown value error. For example, the following command will cause an unknown value error because `--base-url` has two arguments:

```sh
$ ./bin/cli upload-browser --base-url 123 xyz
```

If a user is using a wildcard argument and we get an unknown value, it's likely that this is because the wildcard isn't wrapped in quotes — i.e. `--base-url *` should be `--base-url "*"`

This is hard to know for sure because asterisk expansion happens in the shell before the CLI is run, so we have to guess that this happened