### PR TITLE
Fix typos and unclear wording

### DIFF
--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -601,7 +601,7 @@ test('cli: upload-react-native fails without any version given', async () => {
 
   expect(reactNative.uploadOne).not.toHaveBeenCalled()
   expect(reactNative.fetchAndUploadOne).not.toHaveBeenCalled()
-  expect(logger.error).toHaveBeenCalledWith('--code-bundle-id or at least one of --app-version, --app-version-code and --app-bundle-version must be given')
+  expect(logger.error).toHaveBeenCalledWith('--code-bundle-id or at least one of --app-version, --app-version-code or --app-bundle-version must be given')
   expect(process.exitCode).toBe(1)
 })
 

--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -97,7 +97,7 @@ const browserCommandSingleDefs = [
   {
     name: 'bundle-url',
     type: String,
-    description: 'the URL the bundle is served at (may contain * wildcards) {bold required}',
+    description: 'the URL of the bundle file (may contain * wildcards) {bold required}',
     typeLabel: '{underline url}'
   },
   {
@@ -117,7 +117,7 @@ const browserCommandMultipleDefs = [
   {
     name: 'base-url',
     type: String,
-    description: 'the base URL that JS bundles are served from (may contain * wildcards) {bold required}',
+    description: 'the URL of the base directory that bundles are served from (may contain * wildcards) {bold required}',
     typeLabel: '{underline url}'
   },
 ]

--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -127,7 +127,7 @@ function validateBrowserOpts (opts: Record<string, unknown>): void {
   const anySingleSet = opts['sourceMap'] || opts['bundleUrl'] || opts['bundle']
   const anyMultipleSet = opts['baseUrl'] || opts['directory']
   if (anySingleSet && anyMultipleSet) {
-    throw new Error('Incompatible options are set. Use either single mode options (--source-map, --bundle, --bundle-url) or multiple mode options (--directory,--base-url).')
+    throw new Error('Incompatible options are set. Use either single mode options (--source-map, --bundle, --bundle-url) or multiple mode options (--directory, --base-url).')
   }
   if (!anySingleSet && !anyMultipleSet) throw new Error('Not enough options supplied')
 

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -207,7 +207,7 @@ function validateVersion(opts: Record<string, unknown>): void {
   }
 
   if (!opts.appVersion && !opts.appVersionCode && !opts.appBundleVersion) {
-    throw new Error('--code-bundle-id or at least one of --app-version, --app-version-code and --app-bundle-version must be given')
+    throw new Error('--code-bundle-id or at least one of --app-version, --app-version-code or --app-bundle-version must be given')
   }
 }
 

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -226,7 +226,7 @@ function validatePlatformOptions(opts: Record<string, unknown>): void {
 
 function validateRetrieval(opts: Record<string, unknown>): void {
   if (!opts.fetch && !opts.sourceMap && !opts.bundle) {
-    throw new Error('--fetch or both --source-map and --bundle are required parameters')
+    throw new Error('Not enough arguments provided. Either use --fetch mode, or provide both --source-map and --bundle.')
   }
 
   if (!opts.fetch) {

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -225,7 +225,11 @@ function validatePlatformOptions(opts: Record<string, unknown>): void {
 }
 
 function validateRetrieval(opts: Record<string, unknown>): void {
-  if (!opts.fetch){
+  if (!opts.fetch && !opts.sourceMap && !opts.bundle) {
+    throw new Error('--fetch or both --source-map and --bundle are required parameters')
+  }
+
+  if (!opts.fetch) {
     if (!opts.sourceMap || typeof opts.sourceMap !== 'string') {
       throw new Error('--source-map is a required parameter')
     }

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -69,7 +69,10 @@ export async function uploadOne ({
       sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
       overwrite: overwrite
     }, requestOpts)
-    logger.success(`Success, uploaded ${sourceMap} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
+
+    const uploadedFiles = (bundleContent && fullBundlePath) ? `${sourceMap} and ${bundle}` : sourceMap
+
+    logger.success(`Success, uploaded ${uploadedFiles} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {
       logger.error(formatErrorLog(e), e, e.cause)
@@ -155,7 +158,10 @@ export async function uploadMultiple ({
         sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
         overwrite: overwrite
       }, requestOpts)
-      logger.success(`Success, uploaded ${sourceMap} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
+
+      const uploadedFiles = (bundleContent && fullBundlePath) ? `${sourceMap} and ${bundlePath}` : sourceMap
+
+      logger.success(`Success, uploaded ${uploadedFiles} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
     } catch (e) {
       if (e.cause) {
         logger.error(formatErrorLog(e), e, e.cause)

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -56,7 +56,7 @@ export async function uploadOne ({
     appVersion = await detectAppVersion(projectRoot, logger)
   }
 
-  logger.debug(`Initiating upload "${endpoint}"`)
+  logger.debug(`Initiating upload to "${endpoint}"`)
   const start = new Date().getTime()
   try {
     await request(endpoint, {
@@ -146,7 +146,7 @@ export async function uploadMultiple ({
 
     const transformedSourceMap = await applyTransformations(fullSourceMapPath, sourceMapJson, projectRoot, logger)
 
-    logger.debug(`Initiating upload "${endpoint}"`)
+    logger.debug(`Initiating upload to "${endpoint}"`)
     const start = new Date().getTime()
     try {
       await request(endpoint, {

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -39,7 +39,7 @@ export async function uploadOne ({
   requestOpts = {},
   logger = noopLogger
 }: UploadSingleOpts): Promise<void> {
-  logger.info(`Uploading browser source map for "${bundleUrl}"`)
+  logger.info(`Preparing upload of browser source map for "${bundleUrl}"`)
 
   const [ sourceMapContent, fullSourceMapPath ] = await readSourceMap(sourceMap, projectRoot, logger)
 
@@ -103,7 +103,7 @@ export async function uploadMultiple ({
   requestOpts = {},
   logger = noopLogger
 }: UploadMultipleOpts): Promise<void> {
-  logger.info(`Uploading browser source maps for "${baseUrl}"`)
+  logger.info(`Preparing upload of browser source maps for "${baseUrl}"`)
   logger.debug(`Searching for source maps "${directory}"`)
   const absoluteSearchPath = path.resolve(projectRoot, directory)
   const sourceMaps: string[] = await new Promise((resolve, reject) => {

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -118,7 +118,7 @@ export async function uploadMultiple ({
     return
   }
 
-  logger.debug(`Found ${sourceMaps.length} source map:`)
+  logger.debug(`Found ${sourceMaps.length} source map(s):`)
   logger.debug(`  ${sourceMaps.join(', ')}`)
 
   if (!appVersion) {

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -59,7 +59,7 @@ export async function uploadOne ({
       sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
       overwrite: overwrite
     }, requestOpts)
-    logger.success(`Success, uploaded ${sourceMap} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
+    logger.success(`Success, uploaded ${sourceMap} and ${bundle} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {
       logger.error(formatErrorLog(e), e, e.cause)
@@ -143,7 +143,10 @@ export async function uploadMultiple ({
         sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
         overwrite: overwrite
       }, requestOpts)
-      logger.success(`Success, uploaded ${sourceMap} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
+
+      const uploadedFiles = (bundleContent && fullBundlePath) ? `${sourceMap} and ${bundlePath}` : sourceMap
+
+      logger.success(`Success, uploaded ${uploadedFiles} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
     } catch (e) {
       if (e.cause) {
         logger.error(formatErrorLog(e), e, e.cause)

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -47,7 +47,7 @@ export async function uploadOne ({
     appVersion = await detectAppVersion(projectRoot, logger)
   }
 
-  logger.debug(`Initiating upload "${endpoint}"`)
+  logger.debug(`Initiating upload to "${endpoint}"`)
   const start = new Date().getTime()
   try {
     await request(endpoint, {
@@ -131,7 +131,7 @@ export async function uploadMultiple ({
 
     const transformedSourceMap = await applyTransformations(fullSourceMapPath, sourceMapJson, projectRoot, logger)
 
-    logger.debug(`Initiating upload "${endpoint}"`)
+    logger.debug(`Initiating upload to "${endpoint}"`)
     const start = new Date().getTime()
     try {
       await request(endpoint, {

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -35,7 +35,7 @@ export async function uploadOne ({
   requestOpts = {},
   logger = noopLogger
 }: UploadSingleOpts): Promise<void> {
-  logger.info(`Uploading node source map for "${bundle}"`)
+  logger.info(`Preparing upload of node source map for "${bundle}"`)
 
   const [ sourceMapContent, fullSourceMapPath ] = await readSourceMap(sourceMap, projectRoot, logger)
   const [ bundleContent, fullBundlePath ] = await readBundleContent(bundle, projectRoot, sourceMap, logger)
@@ -91,7 +91,7 @@ export async function uploadMultiple ({
   requestOpts = {},
   logger = noopLogger
 }: UploadMultipleOpts): Promise<void> {
-  logger.info(`Uploading node source maps for "${directory}"`)
+  logger.info(`Preparing upload of node source maps for "${directory}"`)
   logger.debug(`Searching for source maps "${directory}"`)
   const absoluteSearchPath = path.resolve(projectRoot, directory)
   const sourceMaps: string[] = await new Promise((resolve, reject) => {

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -58,7 +58,7 @@ export async function uploadOne ({
 
   const marshalledVersions = marshallVersionOptions({ appVersion, codeBundleId, appBundleVersion, appVersionCode }, platform)
 
-  logger.debug(`Initiating upload "${endpoint}"`)
+  logger.debug(`Initiating upload to "${endpoint}"`)
   const start = new Date().getTime()
   try {
     await request(endpoint, {
@@ -141,7 +141,7 @@ export async function fetchAndUploadOne ({
 
   const marshalledVersions = marshallVersionOptions({ appVersion, codeBundleId, appBundleVersion, appVersionCode }, platform)
 
-  logger.debug(`Initiating upload "${endpoint}"`)
+  logger.debug(`Initiating upload to "${endpoint}"`)
   const start = new Date().getTime()
   try {
     await request(endpoint, {

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -194,7 +194,7 @@ function formatFetchError(err: Error, url: string, entryPoint: string): string {
       return `Unable to connect to ${url}. Is the server running?\n\n`
 
     case NetworkErrorCode.SERVER_ERROR:
-      return `Recieved an error from the server. Does the entry point file '${entryPoint}' exist?\n\n`
+      return `Received an error from the server. Does the entry point file '${entryPoint}' exist?\n\n`
 
     case NetworkErrorCode.TIMEOUT:
       return `The request timed out.\n\n`

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -71,7 +71,7 @@ export async function uploadOne ({
       ...marshalledVersions,
       overwrite
     }, requestOpts)
-    logger.success(`Success, uploaded ${sourceMap} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
+    logger.success(`Success, uploaded ${sourceMap} and ${bundle} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {
       logger.error(formatErrorLog(e), e, e.cause)

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -48,7 +48,7 @@ export async function uploadOne ({
   requestOpts = {},
   logger = noopLogger
 }: UploadSingleOpts): Promise<void> {
-  logger.info(`Uploading React Native source map (${dev ? 'dev' : 'release'} / ${platform})`)
+  logger.info(`Preparing upload of React Native source map (${dev ? 'dev' : 'release'} / ${platform})`)
 
   const [ sourceMapContent, fullSourceMapPath ] = await readSourceMap(sourceMap, projectRoot, logger)
   const [ bundleContent, fullBundlePath ] = await readBundleContent(bundle, projectRoot, sourceMap, logger)
@@ -103,7 +103,7 @@ export async function fetchAndUploadOne ({
   bundlerEntryPoint = 'index.js',
   logger = noopLogger
 }: FetchUploadOpts): Promise<void> {
-  logger.info(`Fetching and uploading React Native source map (${dev ? 'dev' : 'release'} / ${platform})`)
+  logger.info(`Fetching React Native source map (${dev ? 'dev' : 'release'} / ${platform})`)
 
   const queryString = qs.stringify({ platform, dev })
   const entryPoint = bundlerEntryPoint.replace(/\.js$/, '')

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -719,7 +719,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (server error)',
     expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining("Recieved an error from the server. Does the entry point file 'index.js' exist?"),
+      expect.stringContaining("Received an error from the server. Does the entry point file 'index.js' exist?"),
       err
     )
   }
@@ -905,7 +905,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (server error)', asy
     expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining("Recieved an error from the server. Does the entry point file 'index.js' exist?"),
+      expect.stringContaining("Received an error from the server. Does the entry point file 'index.js' exist?"),
       err
     )
   }


### PR DESCRIPTION
## Goal

Fixes a bunch of typos and unclear wording found when testing tool

Each is fixed in a separate commit, so may be easier to review that way

> `Uploading browser source map for ""` should possibly be `Preparing upload of browser source map for ""`, as we don’t initiate the upload til later. When an error occurs after this info, it’s not clear if the upload has partially completed.

> Missing space in incompatible options error message

> › Found 2 source map:
> map needs pluralization (e.g. soure map(s)) when > 1 map found.

> When uploading with the directory option, the success message says
> `✔ Success, uploaded bundle_b.js.map to https://upload.bugsnag.com/source-map in 555ms`
> but I assume the bundle was also uploaded because it does read it (above log was › Reading bundle file "bundle_b.js"). Maybe the success message should say uploaded map x & bundle y ?

> In this error message:
> `ERROR  --code-bundle-id or at least one of --app-version, --app-version-code and --app-bundle-version must be given`
> The and should be an or. Shouldn’t be possible to give a version code and bundle version.

> Missing --source-map and --fetch: returns error:
> `ERROR  --source-map is a required`
> maybe we should add “--source-map or --fetch” as required parameters?

^ For this one I changed it to `--fetch or both --source-map and --bundle are required parameters` as both `--source-map` and `--bundle1 are required

> Typo in “Recieved”:
> `ERROR Recieved an error from the server.`

> › Initiating upload "https://upload.bugsnag.com/react-native-source-map" reads strangely. May be better as:
> › Initiating upload to "https://upload.bugsnag.com/react-native-source-map" to make it a little clearer.