### PR TITLE
Remove 'required' from --fetch option

### DIFF
--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -152,7 +152,7 @@ const reactNativeFetchOpts = [
   {
     name: 'fetch',
     type: Boolean,
-    description: 'enable fetch mode {bold required}',
+    description: 'enable fetch mode',
   },
   {
     name: 'bundler-url',


### PR DESCRIPTION
## Goal

The --fetch option is _kind of_ required (to change to fetch mode) but, as it has no value, it's also a bit weird to mark as required