### PR TITLE
Change "bundles" -> "files" in base-url help

### DIFF
--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -125,7 +125,7 @@ const browserCommandMultipleDefs = [
   {
     name: 'base-url',
     type: String,
-    description: 'the URL of the base directory that bundles are served from (may contain * wildcards) {bold required}',
+    description: 'the URL of the base directory that JS files are served from (may contain * wildcards) {bold required}',
     typeLabel: '{underline url}'
   },
 ]


### PR DESCRIPTION
## Goal

In some cases the files may not be bundles, e.g. if using Typescript to output compiled files individually, so using "bundles" here might not be accurate