### PR TITLE
Add the bundler URL to fetch errors

### DIFF
--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -186,7 +186,7 @@ function marshallVersionOptions ({ appVersion, codeBundleId, appVersionCode, app
 
 function formatFetchError(err: Error, url: string, entryPoint: string): string {
   if (!(err instanceof NetworkError)) {
-    return `An unexpected error occurred.\n\n`
+    return `An unexpected error occurred during the request to ${url}.\n\n`
   }
 
   switch (err.code) {
@@ -194,12 +194,12 @@ function formatFetchError(err: Error, url: string, entryPoint: string): string {
       return `Unable to connect to ${url}. Is the server running?\n\n`
 
     case NetworkErrorCode.SERVER_ERROR:
-      return `Received an error from the server. Does the entry point file '${entryPoint}' exist?\n\n`
+      return `Received an error from the server at ${url}. Does the entry point file '${entryPoint}' exist?\n\n`
 
     case NetworkErrorCode.TIMEOUT:
-      return `The request timed out.\n\n`
+      return `The request to ${url} timed out.\n\n`
 
     default:
-      return `An unexpected error occurred.\n\n`
+      return `An unexpected error occurred during the request to ${url}.\n\n`
   }
 }

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -619,7 +619,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (generic Error)'
     expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('An unexpected error occurred'),
+      expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
       err
     )
   }
@@ -651,7 +651,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (generic Network
     expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('An unexpected error occurred'),
+      expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
       err
     )
   }
@@ -719,7 +719,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (server error)',
     expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining("Received an error from the server. Does the entry point file 'index.js' exist?"),
+      expect.stringContaining("Received an error from the server at http://react-native-bundler:1234. Does the entry point file 'index.js' exist?"),
       err
     )
   }
@@ -753,7 +753,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (timeout)', asyn
     expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('The request timed out.'),
+      expect.stringContaining('The request to http://react-native-bundler:1234 timed out.'),
       err
     )
   }
@@ -790,7 +790,7 @@ test('fethchAndUploadOne(): Fetch mode failure to get bundle (generic Error)', a
     expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('An unexpected error occurred'),
+      expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
       err
     )
   }
@@ -827,7 +827,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (generic NetworkErro
     expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('An unexpected error occurred'),
+      expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
       err
     )
   }
@@ -905,7 +905,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (server error)', asy
     expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining("Received an error from the server. Does the entry point file 'index.js' exist?"),
+      expect.stringContaining("Received an error from the server at http://react-native-bundler:1234. Does the entry point file 'index.js' exist?"),
       err
     )
   }
@@ -944,7 +944,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (timeout)', async ()
     expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('The request timed out.'),
+      expect.stringContaining('The request to http://react-native-bundler:1234 timed out.'),
       err
     )
   }


### PR DESCRIPTION
## Goal

Add the bundler URL to fetch errors so that errors due to using the incorrect bundler URL are easier to spot