### PR TITLE
Allow ".bundle" extension for entry point files

### DIFF
--- a/src/commands/CommandDefinitions.ts
+++ b/src/commands/CommandDefinitions.ts
@@ -1,7 +1,7 @@
 export const commonCommandDefs = [
   { name: 'api-key', type: String, description: 'your project\'s API key {bold required}' },
   { name: 'overwrite', type: Boolean, description: 'whether to replace exiting source maps uploaded with the same version' },
-  { name: 'project-root', type: String, description: 'the top level directory of your project' },
+  { name: 'project-root', type: String, description: 'the top level directory of your project (defaults to the current directory)' },
   { name: 'endpoint', type: String, description: 'customize the endpoint for Bugsnag On-Premise' },
   { name: 'quiet', type: Boolean, description: 'less verbose logging' },
 ]

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -157,13 +157,13 @@ const reactNativeFetchOpts = [
   {
     name: 'bundler-url',
     type: String,
-    description: 'the URL of the React Native bundle server',
+    description: 'the URL of the React Native bundle server (defaults to http://localhost:8081)',
     typeLabel: '{underline url}',
   },
   {
     name: 'bundler-entry-point',
     type: String,
-    description: 'the entry point file of your React Native app',
+    description: 'the entry point file of your React Native app (defaults to index.js)',
     typeLabel: '{underline filepath}',
   },
 ]

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -163,7 +163,7 @@ const reactNativeFetchOpts = [
   {
     name: 'bundler-entry-point',
     type: String,
-    description: 'the entry point of your React Native app',
+    description: 'the entry point file of your React Native app',
     typeLabel: '{underline filepath}',
   },
 ]

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -106,7 +106,7 @@ export async function fetchAndUploadOne ({
   logger.info(`Fetching React Native source map (${dev ? 'dev' : 'release'} / ${platform})`)
 
   const queryString = qs.stringify({ platform, dev })
-  const entryPoint = bundlerEntryPoint.replace(/\.js$/, '')
+  const entryPoint = bundlerEntryPoint.replace(/\.(js|bundle)$/, '')
 
   const sourceMapUrl = `${bundlerUrl}/${entryPoint}.js.map?${queryString}`
   const bundleUrl = `${bundlerUrl}/${entryPoint}.bundle?${queryString}`


### PR DESCRIPTION
## Goal

There was some confusion in testing with the `--bundler-entry-point` option — this is intended to be a file (i.e. "index.js" in most cases) that we request the bundle for but a user was providing the bundle file name instead (i.e. "index.bundle")

This PR adds the word "file" to the option help text, so hopefully it's a bit clearer and allows the ".bundle" extension as well