### PR TITLE
Remove log that can be excessively noisy

### DIFF
--- a/src/transformers/AddSources.ts
+++ b/src/transformers/AddSources.ts
@@ -22,7 +22,6 @@ export default async function addSources (sourceMapPath: string, sourceMap: unkn
 
 async function addSourcesContent (sourceMapPath: string, map: UnsafeSourceMap, projectRoot: string, logger: Logger) {
   if (map.sources?.length === map.sourcesContent?.length) {
-    logger.debug('sourcesContent is already included in source map')
     return map
   }
 


### PR DESCRIPTION
## Goal

In RAM bundles there can be many sub-source maps, each of which result in a log message when the `sourcesContent` is present

Consola squishes these together for us ([see source](https://github.com/nuxt-contrib/consola/blob/eaad4bc5ee1e4d0ee326d88ecf921f747a07eed9/src/consola.js#L240-L253)) but it's still quite noisy before we hit the threshold and we could be logging hundreds of messages if the user provides a custom logger

I opted not to add another log for when we are adding `sourcesContent ` because there doesn't seem to be anything useful that's unique — the file path is shared between every sub-source map, so we would end up with the same problem if `sourcesContent` was missing