### PR TITLE
Ci timeouts fix

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -27,3 +27,5 @@ jobs:
 
     - name: Test
       run: npm run test
+      env:
+        BUGSNAG_TIMEOUT_MS: 5000

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [10.x, 12.x, 14.x]
     steps:

--- a/.jest/setup.js
+++ b/.jest/setup.js
@@ -1,2 +1,2 @@
-process.env.BUGSNAG_RETRY_INTERVAL_MS = '10'
-process.env.BUGSNAG_TIMEOUT_MS = '250'
+process.env.BUGSNAG_RETRY_INTERVAL_MS = process.env.BUGSNAG_RETRY_INTERVAL_MS || '10'
+process.env.BUGSNAG_TIMEOUT_MS = process.env.BUGSNAG_TIMEOUT_MS || '100'

--- a/src/__test__/Request.test.ts
+++ b/src/__test__/Request.test.ts
@@ -5,6 +5,9 @@ import { AddressInfo } from 'net'
 import multiparty from 'multiparty'
 import File from '../File'
 
+// Allow 10x the request timeout time per-test
+jest.setTimeout(+(process.env.BUGSNAG_TIMEOUT_MS as string) * 10)
+
 let server: http.Server
 afterEach(() => server?.close())
 


### PR DESCRIPTION
## Goal

This is a quick fix for the timeout issues that we've been having due to slow test runs on CI. I've massively bumped the timeout on CI and the time Jest will let the Request tests run

Reworking the tests themselves so that they are not susceptible to timing issues will be done in a separate piece of work