### PR TITLE
Clarify --directory is relative to --project-root

### DIFF
--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -119,7 +119,7 @@ const browserCommandMultipleDefs = [
   {
     name: 'directory',
     type: String,
-    description: 'the directory to start searching for source maps in {bold required}',
+    description: 'the directory to start searching for source maps in, relative to the project root {bold required}',
     typeLabel: '{underline path}'
   },
   {

--- a/src/commands/UploadNodeCommand.ts
+++ b/src/commands/UploadNodeCommand.ts
@@ -103,7 +103,7 @@ const nodeCommandMultipleDefs = [
   {
     name: 'directory',
     type: String,
-    description: 'the directory to start searching for source maps in {bold required}',
+    description: 'the directory to start searching for source maps in, relative to the project root {bold required}',
     typeLabel: '{underline path}'
   }
 ]


### PR DESCRIPTION
## Goal

Currently it's unclear where `--directory` is relative to if `--project-root` is also specified. This PR updates the help text to make that explicit

This shouldn't be a problem for most users as `--project-root` defaults to the current working directory, so there's no ambiguity if it's unspecified