### PR TITLE
Gate detection of appVersion behind a new --detect-app-version flag

### DIFF
--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -111,11 +111,12 @@ Feature: Browser source map upload multiple
     And the payload field "sourceMap" matches the source map "b.json" for "multiple-source-map-typescript"
     And the payload field "minifiedFile" matches the minified file "b.js" for "multiple-source-map-typescript"
 
-  Scenario: Auto detecting app version
+  Scenario: Detected app version
     When I run the service "multiple-source-map-webpack" with the command
       """
       bugsnag-source-maps upload-browser
         --api-key 123
+        --detect-app-version
         --directory dist
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339

--- a/features/browser-upload-one.feature
+++ b/features/browser-upload-one.feature
@@ -62,11 +62,12 @@ Feature: Browser source map upload one
     And the Content-Type header is valid multipart form-data
     And the exit code is successful
 
-  Scenario: Auto detecting app version
+  Scenario: Detected app version
     When I run the service "single-source-map-webpack" with the command
       """
       bugsnag-source-maps upload-browser
         --api-key 123
+        --detect-app-version
         --source-map dist/main.js.map
         --bundle dist/main.js
         --bundle-url "http://myapp.url/static/js/main.js"

--- a/features/node-upload-multiple.feature
+++ b/features/node-upload-multiple.feature
@@ -107,11 +107,12 @@ Feature: Node source map upload multiple
     And the payload field "sourceMap" matches the source map "b.json" for "multiple-source-map-typescript"
     And the payload field "minifiedFile" matches the minified file "b.js" for "multiple-source-map-typescript"
 
-  Scenario: Auto detecting app version
+  Scenario: Detected app version
     When I run the service "multiple-source-map-webpack" with the command
       """
       bugsnag-source-maps upload-node
         --api-key 123
+        --detect-app-version
         --directory dist
         --endpoint http://maze-runner:9339
       """

--- a/features/node-upload-one.feature
+++ b/features/node-upload-one.feature
@@ -59,11 +59,12 @@ Feature: Node source map upload one
     And the Content-Type header is valid multipart form-data
     And the exit code is successful
 
-  Scenario: Auto detecting app version
+  Scenario: Detected app version
     When I run the service "single-source-map-webpack" with the command
       """
       bugsnag-source-maps upload-node
         --api-key 123
+        --detect-app-version
         --source-map dist/main.js.map
         --bundle dist/main.js
         --endpoint http://maze-runner:9339

--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -109,6 +109,18 @@ test('cli: upload-node --quiet', async () => {
   expect(logger.level).toBe(LogLevel.Success)
 })
 
+test('cli: upload-node --app-version and --detect-app-version', async () => {
+  await run([
+    'upload-node',
+    '--api-key', '123',
+    '--source-map', 'bundle.js.map',
+    '--app-version', '123',
+    '--detect-app-version'
+  ])
+  expect(process.exitCode).toBe(1)
+  expect(logger.error).toHaveBeenCalledWith('--app-version and --detect-app-version cannot both be given')
+})
+
 // BROWSER
 
 test('cli: upload-browser --help', async () => {

--- a/src/bin/__test__/cli.test.ts
+++ b/src/bin/__test__/cli.test.ts
@@ -185,6 +185,19 @@ test('cli: upload-browser --quiet', async () => {
   expect(logger.level).toBe(LogLevel.Success)
 })
 
+test('cli: upload-browser --app-version and --detect-app-version', async () => {
+  await run([
+    'upload-browser',
+    '--api-key', '123',
+    '--source-map', 'bundle.js.map',
+    '--bundle-url', 'http://my.url/dist/bundle.js',
+    '--app-version', '123',
+    '--detect-app-version'
+  ])
+  expect(process.exitCode).toBe(1)
+  expect(logger.error).toHaveBeenCalledWith('--app-version and --detect-app-version cannot both be given')
+})
+
 // REACT NATIVE
 
 test('cli: upload-react-native --help', async () => {

--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -47,6 +47,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
         overwrite: browserOpts.overwrite,
         appVersion: browserOpts.appVersion,
         endpoint: browserOpts.endpoint,
+        detectAppVersion: browserOpts.detectAppVersion,
         logger
       })
     } else {
@@ -59,6 +60,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
         overwrite: browserOpts.overwrite,
         appVersion: browserOpts.appVersion,
         endpoint: browserOpts.endpoint,
+        detectAppVersion: browserOpts.detectAppVersion,
         logger
       })
     }
@@ -93,7 +95,17 @@ function browserUsage (): void {
   )
 }
 
-const browserCommandCommonDefs = [ { name: 'app-version', type: String } ]
+const browserCommandCommonDefs = [
+  {
+    name: 'app-version',
+    type: String
+  },
+  {
+    name: 'detect-app-version',
+    type: Boolean,
+    description: 'detect the app version from the package.json file'
+  }
+]
 
 const browserCommandSingleDefs = [
   {
@@ -131,7 +143,14 @@ const browserCommandMultipleDefs = [
 ]
 
 function validateBrowserOpts (opts: Record<string, unknown>): void {
-  if (!opts['apiKey']) throw new Error('--api-key is required')
+  if (!opts['apiKey']) {
+    throw new Error('--api-key is required')
+  }
+
+  if (opts['appVersion'] && opts['detectAppVersion']) {
+    throw new Error('--app-version and --detect-app-version cannot both be given')
+  }
+
   const anySingleSet = opts['sourceMap'] || opts['bundleUrl'] || opts['bundle']
   const anyMultipleSet = opts['baseUrl'] || opts['directory']
   if (anySingleSet && anyMultipleSet) {

--- a/src/commands/UploadNodeCommand.ts
+++ b/src/commands/UploadNodeCommand.ts
@@ -38,6 +38,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
         overwrite: nodeOpts.overwrite,
         appVersion: nodeOpts.appVersion,
         endpoint: nodeOpts.endpoint,
+        detectAppVersion: nodeOpts.detectAppVersion,
         logger
       })
     } else {
@@ -49,6 +50,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
         overwrite: nodeOpts.overwrite,
         appVersion: nodeOpts.appVersion,
         endpoint: nodeOpts.endpoint,
+        detectAppVersion: nodeOpts.detectAppVersion,
         logger
       })
     }
@@ -83,7 +85,17 @@ function nodeUsage (): void {
   )
 }
 
-const nodeCommandCommonDefs = [ { name: 'app-version', type: String } ]
+const nodeCommandCommonDefs = [
+  {
+    name: 'app-version',
+    type: String
+  },
+  {
+    name: 'detect-app-version',
+    type: Boolean,
+    description: 'detect the app version from the package.json file'
+  }
+]
 
 const nodeCommandSingleDefs = [
   {
@@ -109,7 +121,14 @@ const nodeCommandMultipleDefs = [
 ]
 
 function validatenodeOpts (opts: Record<string, unknown>): void {
-  if (!opts['apiKey']) throw new Error('--api-key is required')
+  if (!opts['apiKey']) {
+    throw new Error('--api-key is required')
+  }
+
+  if (opts['appVersion'] && opts['detectAppVersion']) {
+    throw new Error('--app-version and --detect-app-version cannot both be given')
+  }
+
   const anySingleSet = opts['sourceMap'] || opts['bundle']
   const anyMultipleSet = opts['directory']
   if (anySingleSet && anyMultipleSet) {

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -10,7 +10,7 @@ import applyTransformations from './lib/ApplyTransformations'
 import readBundleContent from './lib/ReadBundleContent'
 import readSourceMap from './lib/ReadSourceMap'
 import parseSourceMap from './lib/ParseSourceMap'
-import detectAppVersion from './lib/DetectAppVersion'
+import _detectAppVersion from './lib/DetectAppVersion'
 
 interface UploadSingleOpts {
   apiKey: string
@@ -22,6 +22,7 @@ interface UploadSingleOpts {
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
+  detectAppVersion?: boolean,
   requestOpts?: http.RequestOptions
   logger?: Logger
 }
@@ -36,6 +37,7 @@ export async function uploadOne ({
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = 'https://upload.bugsnag.com/',
+  detectAppVersion = false,
   requestOpts = {},
   logger = noopLogger
 }: UploadSingleOpts): Promise<void> {
@@ -52,9 +54,9 @@ export async function uploadOne ({
   const sourceMapJson = parseSourceMap(sourceMapContent, sourceMap, logger)
   const transformedSourceMap = await applyTransformations(fullSourceMapPath, sourceMapJson, projectRoot, logger)
 
-  if (!appVersion) {
+  if (detectAppVersion) {
     try {
-      appVersion = await detectAppVersion(projectRoot, logger)
+      appVersion = await _detectAppVersion(projectRoot, logger)
     } catch (e) {
       logger.error(e.message)
 
@@ -97,6 +99,7 @@ interface UploadMultipleOpts {
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
+  detectAppVersion?: boolean,
   requestOpts?: http.RequestOptions
   logger?: Logger
 }
@@ -109,6 +112,7 @@ export async function uploadMultiple ({
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = 'https://upload.bugsnag.com/',
+  detectAppVersion = false,
   requestOpts = {},
   logger = noopLogger
 }: UploadMultipleOpts): Promise<void> {
@@ -130,9 +134,9 @@ export async function uploadMultiple ({
   logger.debug(`Found ${sourceMaps.length} source map(s):`)
   logger.debug(`  ${sourceMaps.join(', ')}`)
 
-  if (!appVersion) {
+  if (detectAppVersion) {
     try {
-      appVersion = await detectAppVersion(projectRoot, logger)
+      appVersion = await _detectAppVersion(projectRoot, logger)
     } catch (e) {
       logger.error(e.message)
 

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -10,7 +10,7 @@ import applyTransformations from './lib/ApplyTransformations'
 import readBundleContent from './lib/ReadBundleContent'
 import readSourceMap from './lib/ReadSourceMap'
 import parseSourceMap from './lib/ParseSourceMap'
-import detectAppVersion from './lib/DetectAppVersion'
+import _detectAppVersion from './lib/DetectAppVersion'
 
 interface UploadSingleOpts {
   apiKey: string
@@ -20,6 +20,7 @@ interface UploadSingleOpts {
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
+  detectAppVersion?: boolean
   requestOpts?: http.RequestOptions
   logger?: Logger
 }
@@ -32,6 +33,7 @@ export async function uploadOne ({
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = 'https://upload.bugsnag.com/',
+  detectAppVersion = false,
   requestOpts = {},
   logger = noopLogger
 }: UploadSingleOpts): Promise<void> {
@@ -43,9 +45,9 @@ export async function uploadOne ({
   const sourceMapJson = parseSourceMap(sourceMapContent, sourceMap, logger)
   const transformedSourceMap = await applyTransformations(fullSourceMapPath, sourceMapJson, projectRoot, logger)
 
-  if (!appVersion) {
+  if (detectAppVersion) {
     try {
-      appVersion = await detectAppVersion(projectRoot, logger)
+      appVersion = await _detectAppVersion(projectRoot, logger)
     } catch (e) {
       logger.error(e.message)
 
@@ -83,6 +85,7 @@ interface UploadMultipleOpts {
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
+  detectAppVersion?: boolean
   requestOpts?: http.RequestOptions
   logger?: Logger
 }
@@ -94,6 +97,7 @@ export async function uploadMultiple ({
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = 'https://upload.bugsnag.com/',
+  detectAppVersion = false,
   requestOpts = {},
   logger = noopLogger
 }: UploadMultipleOpts): Promise<void> {
@@ -115,9 +119,9 @@ export async function uploadMultiple ({
   logger.debug(`Found ${sourceMaps.length} source map(s):`)
   logger.debug(`  ${sourceMaps.join(', ')}`)
 
-  if (!appVersion) {
+  if (detectAppVersion) {
     try {
-      appVersion = await detectAppVersion(projectRoot, logger)
+      appVersion = await _detectAppVersion(projectRoot, logger)
     } catch (e) {
       logger.error(e.message)
 

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -154,6 +154,7 @@ test('uploadOne(): fails when unable to detect appVersion', async () => {
       projectRoot: path.join(__dirname, 'fixtures/h'),
       sourceMap: 'build/static/js/2.e5bb21a6.chunk.js.map',
       bundle: 'build/static/js/2.e5bb21a6.chunk.js',
+      detectAppVersion: true,
       logger: mockLogger
     })
     expect(mockedRequest).not.toHaveBeenCalled()
@@ -301,7 +302,7 @@ test('uploadOne(): failure (timeout)', async () => {
   }
 })
 
-test('uploadMultiple(): success', async () => {
+test('uploadMultiple(): success with detected appVersion', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
   mockedRequest.mockResolvedValue()
   await uploadMultiple({
@@ -309,6 +310,7 @@ test('uploadMultiple(): success', async () => {
     baseUrl: 'http://mybundle.jim/',
     directory: 'build',
     projectRoot: path.join(__dirname, 'fixtures/c'),
+    detectAppVersion: true,
     logger: mockLogger
   })
   expect(mockedRequest).toHaveBeenCalledTimes(4)
@@ -480,6 +482,7 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
     baseUrl: 'http://mybundle.jim/',
     directory: path.join(__dirname, 'fixtures/c/build'),
     projectRoot: path.join(__dirname, 'fixtures/c'),
+    detectAppVersion: true,
     logger: mockLogger
   })
 
@@ -613,6 +616,7 @@ test('uploadMultiple(): fails when unable to detect appVersion', async () => {
       baseUrl: 'http://mybundle.jim/',
       directory: 'build',
       projectRoot: path.join(__dirname, 'fixtures/h'),
+      detectAppVersion: true,
       logger: mockLogger
     })
     expect(mockedRequest).not.toHaveBeenCalled()

--- a/src/uploaders/__test__/NodeUploader.test.ts
+++ b/src/uploaders/__test__/NodeUploader.test.ts
@@ -41,6 +41,31 @@ test('uploadOne(): dispatches a request with the correct params', async () => {
   )
 })
 
+test('uploadOne(): dispatches a request with the correct params and detected appVersion', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadOne({
+    apiKey: '123',
+    sourceMap: 'build/static/js/2.e5bb21a6.chunk.js.map',
+    bundle: 'build/static/js/2.e5bb21a6.chunk.js',
+    detectAppVersion: true,
+    projectRoot: path.join(__dirname, 'fixtures/c')
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      appVersion: '1.2.3',
+      minifiedFile: expect.any(Object),
+      minifiedUrl: 'build/static/js/2.e5bb21a6.chunk.js',
+      overwrite: false,
+      sourceMap: expect.any(Object)
+    }),
+    expect.objectContaining({})
+  )
+})
+
 test('uploadOne(): fails when unable to detect appVersion', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
   try {
@@ -49,6 +74,7 @@ test('uploadOne(): fails when unable to detect appVersion', async () => {
       projectRoot: path.join(__dirname, 'fixtures/h'),
       sourceMap: 'build/static/js/2.e5bb21a6.chunk.js.map',
       bundle: 'build/static/js/2.e5bb21a6.chunk.js',
+      detectAppVersion: true,
       logger: mockLogger
     })
     expect(mockedRequest).not.toHaveBeenCalled()
@@ -204,6 +230,91 @@ test('uploadMultiple(): success', async () => {
   )
 })
 
+test('uploadMultiple(): success with detected appVersion', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadMultiple({
+    apiKey: '123',
+    directory: 'build/static/js',
+    projectRoot: path.join(__dirname, 'fixtures/c'),
+    logger: mockLogger,
+    detectAppVersion: true
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(4)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/2.e5bb21a6.chunk.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/2.e5bb21a6.chunk.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'build/static/js/2.e5bb21a6.chunk.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/3.1b8b4fc7.chunk.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/3.1b8b4fc7.chunk.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'build/static/js/3.1b8b4fc7.chunk.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/main.286ac573.chunk.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/main.286ac573.chunk.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'build/static/js/main.286ac573.chunk.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/runtime-main.ad66c902.js'),
+        data: expect.any(String)
+      }),
+      sourceMap: expect.objectContaining({
+        filepath: path.join(__dirname, 'fixtures/c/build/static/js/runtime-main.ad66c902.js.map'),
+        data: expect.any(String)
+      }),
+      overwrite: false,
+      minifiedUrl: 'build/static/js/runtime-main.ad66c902.js',
+      appVersion: '1.2.3'
+    }),
+    expect.objectContaining({})
+  )
+})
+
 test('uploadMultiple(): success using absolute path for "directory"', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
   mockedRequest.mockResolvedValue()
@@ -322,6 +433,7 @@ test('uploadMultiple(): fails when unable to detect appVersion', async () => {
       apiKey: '123',
       directory: 'build',
       projectRoot: path.join(__dirname, 'fixtures/h'),
+      detectAppVersion: true,
       logger: mockLogger
     })
     expect(mockedRequest).not.toHaveBeenCalled()


### PR DESCRIPTION
## Goal

Currently the CLI will attempt to automatically detect the appVersion of the project if no`--app-version` argument is given

This may not always be desirable, so this has been gated behind a new `--detect-app-version` flag. This is mutually exclusive with `--app-version` (i.e. both can't be specified as that doesn't make sense)