### PR TITLE
Pin to Maze Runner v3.5.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./:/app
 
   maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:v3.5.1-cli
     environment:
       BUILDKITE_JOB_ID:
       VERBOSE:


### PR DESCRIPTION
## Goal

Temporarily pin to Maze Runner v3.5.1, avoid ambiguous step definitions caused by some steps having been moved into v3.6.0 but not yet removed from the Source Maps repo.