### PR TITLE
docs: Add endpoint instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you are using Bugsnag On-premise, you should use the endpoint option to set t
 ```sh
 # browser/node uploads
 bugsnag-react-native upload-browser \
-  --endpoint https://internal.bugsnag.com/source-map \
+  --endpoint https://bugsnag.my-company.com/source-map \
   # ... other options
 
 # react native uploads

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ bugsnag-react-native upload-browser \
 
 # react native uploads
 bugsnag-react-native upload-react-native \
-  --endpoint https://internal.bugsnag.com/react-native-source-map \
+  --endpoint https://bugsnag.my-company.com/react-native-source-map \
   # ... other options
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ Options
   --version     output the version of the CLI module
 ```
 
+## Bugsnag On-Premise
+
+If you are using Bugsnag On-premise, you should use the endpoint option to set the url of your [upload server](https://docs.bugsnag.com/on-premise/single-machine/service-ports/#bugsnag-upload-server). You must include the correct path, for example:
+
+```sh
+# browser/node uploads
+bugsnag-react-native upload-browser \
+  --endpoint https://internal.bugsnag.com/source-map \
+  # ... other options
+
+# react native uploads
+bugsnag-react-native upload-react-native \
+  --endpoint https://internal.bugsnag.com/react-native-source-map \
+  # ... other options
+```
+
 ## Support
 
 * Check out the [documentation](https://docs.bugsnag.com/build-integrations/js/#uploading-source-maps)


### PR DESCRIPTION
Help On-Premise users get the correct configuration.