### PR TITLE
Use latest Maze Runner release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
       - docker-compose#v3.7.0:
           use-aliases: true
           run: maze-runner
-          command: ["features/browser-upload-one.feature", "features/browser-upload-multiple.feature"]
+          command: ["--fail-fast", "features/browser-upload-one.feature", "features/browser-upload-multiple.feature"]
 
   - label: 'Run Maze Runner tests (node)'
     key: "run-maze-node"
@@ -36,7 +36,7 @@ steps:
       - docker-compose#v3.7.0:
           use-aliases: true
           run: maze-runner
-          command: ["features/node-upload-one.feature", "features/node-upload-multiple.feature"]
+          command: ["--fail-fast", "features/node-upload-one.feature", "features/node-upload-multiple.feature"]
 
   - label: 'Run Maze Runner tests (react native)'
     key: "run-maze-react-native"
@@ -48,7 +48,7 @@ steps:
       - docker-compose#v3.7.0:
           use-aliases: true
           run: maze-runner
-          command: ["features/react-native-upload-one.feature"]
+          command: ["--fail-fast", "features/react-native-upload-one.feature"]
 
   - label: 'Run Maze Runner tests (react native fetch)'
     key: "run-maze-react-native-fetch"
@@ -60,4 +60,4 @@ steps:
       - docker-compose#v3.7.0:
           use-aliases: true
           run: maze-runner
-          command: ["features/react-native-fetch.feature"]
+          command: ["--fail-fast", "features/react-native-fetch.feature"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./:/app
 
   maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:v3.5.1-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli
     environment:
       BUILDKITE_JOB_ID:
       VERBOSE:

--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -215,8 +215,8 @@ Feature: Browser source map upload multiple
     And I wait to receive 5 requests
     Then the exit code is not successful
     And the Content-Type header is valid multipart form-data for all requests
-    And the shell has output "A server side error occurred while processing the upload." to stdout
-    And the shell has output "HTTP status 500 received from upload API" to stdout
+    And the last run docker command output "A server side error occurred while processing the upload."
+    And the last run docker command output "HTTP status 500 received from upload API"
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
     And the payload field "overwrite" is null for all requests
@@ -237,8 +237,8 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The provided API key was invalid." to stdout
-    And the shell has output "HTTP status 401 received from upload API" to stdout
+    And the last run docker command output "The provided API key was invalid."
+    And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -260,8 +260,8 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag." to stdout
-    And the shell has output "HTTP status 409 received from upload API" to stdout
+    And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
+    And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -283,8 +283,8 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The uploaded source map was empty." to stdout
-    And the shell has output "HTTP status 422 received from upload API" to stdout
+    And the last run docker command output "The uploaded source map was empty."
+    And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -306,8 +306,8 @@ Feature: Browser source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The request was rejected by the server as invalid." to stdout
-    And the shell has output "HTTP status 400 received from upload API" to stdout
+    And the last run docker command output "The request was rejected by the server as invalid."
+    And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null

--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -213,7 +213,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 5 requests
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
@@ -236,7 +236,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -259,7 +259,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -282,7 +282,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -305,7 +305,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"

--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -10,7 +10,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -38,7 +38,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -66,7 +66,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -94,7 +94,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -122,7 +122,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "4.5.6" for all requests
@@ -151,7 +151,7 @@ Feature: Browser source map upload multiple
         --overwrite
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -180,7 +180,7 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 4 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests

--- a/features/browser-upload-one.feature
+++ b/features/browser-upload-one.feature
@@ -144,7 +144,7 @@ Feature: Browser source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 5 requests
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
@@ -168,7 +168,7 @@ Feature: Browser source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -192,7 +192,7 @@ Feature: Browser source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -216,7 +216,7 @@ Feature: Browser source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -240,7 +240,7 @@ Feature: Browser source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"

--- a/features/browser-upload-one.feature
+++ b/features/browser-upload-one.feature
@@ -18,7 +18,7 @@ Feature: Browser source map upload one
     And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
-    And the exit code is successful
+    And the last run docker command exited successfully
 
   Scenario: Basic success case (babel)
     When I run the service "single-source-map-babel-browser" with the command
@@ -39,7 +39,7 @@ Feature: Browser source map upload one
     And the payload field "sourceMap" matches the expected source map for "single-source-map-babel-browser"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-babel-browser"
     And the Content-Type header is valid multipart form-data
-    And the exit code is successful
+    And the last run docker command exited successfully
 
   Scenario: Basic success case (typescript)
     When I run the service "single-source-map-typescript" with the command
@@ -60,7 +60,7 @@ Feature: Browser source map upload one
     And the payload field "sourceMap" matches the expected source map for "single-source-map-typescript"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-typescript"
     And the Content-Type header is valid multipart form-data
-    And the exit code is successful
+    And the last run docker command exited successfully
 
   Scenario: Detected app version
     When I run the service "single-source-map-webpack" with the command
@@ -81,7 +81,7 @@ Feature: Browser source map upload one
     And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
-    And the exit code is successful
+    And the last run docker command exited successfully
 
   Scenario: Overwrite enabled
     When I run the service "single-source-map-webpack" with the command
@@ -103,7 +103,7 @@ Feature: Browser source map upload one
     And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
-    And the exit code is successful
+    And the last run docker command exited successfully
 
   Scenario: A request will be retried on a server failure (500 status code)
     When I set the HTTP status code for the next request to 500
@@ -118,7 +118,7 @@ Feature: Browser source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 2 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests

--- a/features/browser-upload-one.feature
+++ b/features/browser-upload-one.feature
@@ -145,8 +145,8 @@ Feature: Browser source map upload one
       """
     And I wait to receive 5 requests
     Then the exit code is not successful
-    And the shell has output "A server side error occurred while processing the upload." to stdout
-    And the shell has output "HTTP status 500 received from upload API" to stdout
+    And the last run docker command output "A server side error occurred while processing the upload."
+    And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -169,8 +169,8 @@ Feature: Browser source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The provided API key was invalid." to stdout
-    And the shell has output "HTTP status 401 received from upload API" to stdout
+    And the last run docker command output "The provided API key was invalid."
+    And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -193,8 +193,8 @@ Feature: Browser source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag." to stdout
-    And the shell has output "HTTP status 409 received from upload API" to stdout
+    And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
+    And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -217,8 +217,8 @@ Feature: Browser source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The uploaded source map was empty." to stdout
-    And the shell has output "HTTP status 422 received from upload API" to stdout
+    And the last run docker command output "The uploaded source map was empty."
+    And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -241,8 +241,8 @@ Feature: Browser source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The request was rejected by the server as invalid." to stdout
-    And the shell has output "HTTP status 400 received from upload API" to stdout
+    And the last run docker command output "The request was rejected by the server as invalid."
+    And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null

--- a/features/node-upload-multiple.feature
+++ b/features/node-upload-multiple.feature
@@ -205,7 +205,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 5 requests
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
@@ -227,7 +227,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -249,7 +249,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -271,7 +271,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -293,7 +293,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"

--- a/features/node-upload-multiple.feature
+++ b/features/node-upload-multiple.feature
@@ -9,7 +9,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -36,7 +36,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -63,7 +63,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -90,7 +90,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -117,7 +117,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "4.5.6" for all requests
@@ -145,7 +145,7 @@ Feature: Node source map upload multiple
         --overwrite
       """
     And I wait to receive 3 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -173,7 +173,7 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 4 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests

--- a/features/node-upload-multiple.feature
+++ b/features/node-upload-multiple.feature
@@ -207,8 +207,8 @@ Feature: Node source map upload multiple
     And I wait to receive 5 requests
     Then the exit code is not successful
     And the Content-Type header is valid multipart form-data for all requests
-    And the shell has output "A server side error occurred while processing the upload." to stdout
-    And the shell has output "HTTP status 500 received from upload API" to stdout
+    And the last run docker command output "A server side error occurred while processing the upload."
+    And the last run docker command output "HTTP status 500 received from upload API"
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
     And the payload field "overwrite" is null for all requests
@@ -228,8 +228,8 @@ Feature: Node source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The provided API key was invalid." to stdout
-    And the shell has output "HTTP status 401 received from upload API" to stdout
+    And the last run docker command output "The provided API key was invalid."
+    And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -250,8 +250,8 @@ Feature: Node source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag." to stdout
-    And the shell has output "HTTP status 409 received from upload API" to stdout
+    And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
+    And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -272,8 +272,8 @@ Feature: Node source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The uploaded source map was empty." to stdout
-    And the shell has output "HTTP status 422 received from upload API" to stdout
+    And the last run docker command output "The uploaded source map was empty."
+    And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -294,8 +294,8 @@ Feature: Node source map upload multiple
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The request was rejected by the server as invalid." to stdout
-    And the shell has output "HTTP status 400 received from upload API" to stdout
+    And the last run docker command output "The request was rejected by the server as invalid."
+    And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null

--- a/features/node-upload-one.feature
+++ b/features/node-upload-one.feature
@@ -134,8 +134,8 @@ Feature: Node source map upload one
       """
     And I wait to receive 5 requests
     Then the exit code is not successful
-    And the shell has output "A server side error occurred while processing the upload." to stdout
-    And the shell has output "HTTP status 500 received from upload API" to stdout
+    And the last run docker command output "A server side error occurred while processing the upload."
+    And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -157,8 +157,8 @@ Feature: Node source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The provided API key was invalid." to stdout
-    And the shell has output "HTTP status 401 received from upload API" to stdout
+    And the last run docker command output "The provided API key was invalid."
+    And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -180,8 +180,8 @@ Feature: Node source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag." to stdout
-    And the shell has output "HTTP status 409 received from upload API" to stdout
+    And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
+    And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -203,8 +203,8 @@ Feature: Node source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The uploaded source map was empty." to stdout
-    And the shell has output "HTTP status 422 received from upload API" to stdout
+    And the last run docker command output "The uploaded source map was empty."
+    And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null
@@ -226,8 +226,8 @@ Feature: Node source map upload one
       """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The request was rejected by the server as invalid." to stdout
-    And the shell has output "HTTP status 400 received from upload API" to stdout
+    And the last run docker command output "The request was rejected by the server as invalid."
+    And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" is null

--- a/features/node-upload-one.feature
+++ b/features/node-upload-one.feature
@@ -17,7 +17,7 @@ Feature: Node source map upload one
     And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
-    And the exit code is successful
+    And the last run docker command exited successfully
 
   Scenario: Basic success case (babel)
     When I run the service "single-source-map-babel-node" with the command
@@ -37,7 +37,7 @@ Feature: Node source map upload one
     And the payload field "sourceMap" matches the expected source map for "single-source-map-babel-node"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-babel-node"
     And the Content-Type header is valid multipart form-data
-    And the exit code is successful
+    And the last run docker command exited successfully
 
   Scenario: Basic success case (typescript)
     When I run the service "single-source-map-typescript" with the command
@@ -57,7 +57,7 @@ Feature: Node source map upload one
     And the payload field "sourceMap" matches the expected source map for "single-source-map-typescript"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-typescript"
     And the Content-Type header is valid multipart form-data
-    And the exit code is successful
+    And the last run docker command exited successfully
 
   Scenario: Detected app version
     When I run the service "single-source-map-webpack" with the command
@@ -77,7 +77,7 @@ Feature: Node source map upload one
     And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
-    And the exit code is successful
+    And the last run docker command exited successfully
 
   Scenario: Overwrite enabled
     When I run the service "single-source-map-webpack" with the command
@@ -98,7 +98,7 @@ Feature: Node source map upload one
     And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
     And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
-    And the exit code is successful
+    And the last run docker command exited successfully
 
   Scenario: A request will be retried on a server failure (500 status code)
     When I set the HTTP status code for the next request to 500
@@ -112,7 +112,7 @@ Feature: Node source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 2 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests

--- a/features/node-upload-one.feature
+++ b/features/node-upload-one.feature
@@ -133,7 +133,7 @@ Feature: Node source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 5 requests
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
@@ -156,7 +156,7 @@ Feature: Node source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -179,7 +179,7 @@ Feature: Node source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -202,7 +202,7 @@ Feature: Node source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -225,7 +225,7 @@ Feature: Node source map upload one
         --endpoint http://maze-runner:9339
       """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"

--- a/features/react-native-fetch.feature
+++ b/features/react-native-fetch.feature
@@ -14,7 +14,7 @@ Feature: React native source map fetch mode
       <flags>
     """
     And I wait to receive 1 request
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
@@ -58,7 +58,7 @@ Feature: React native source map fetch mode
       --platform ios
     """
     And I wait to receive 2 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests

--- a/features/react-native-fetch.feature
+++ b/features/react-native-fetch.feature
@@ -81,7 +81,7 @@ Feature: React native source map fetch mode
       --platform ios
     """
     And I wait to receive 5 requests
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
@@ -106,7 +106,7 @@ Feature: React native source map fetch mode
       --platform ios
     """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -131,7 +131,7 @@ Feature: React native source map fetch mode
       --platform ios
     """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -156,7 +156,7 @@ Feature: React native source map fetch mode
       --platform ios
     """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -181,7 +181,7 @@ Feature: React native source map fetch mode
       --platform ios
     """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"

--- a/features/react-native-fetch.feature
+++ b/features/react-native-fetch.feature
@@ -82,8 +82,8 @@ Feature: React native source map fetch mode
     """
     And I wait to receive 5 requests
     Then the exit code is not successful
-    And the shell has output "A server side error occurred while processing the upload." to stdout
-    And the shell has output "HTTP status 500 received from upload API" to stdout
+    And the last run docker command output "A server side error occurred while processing the upload."
+    And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -107,8 +107,8 @@ Feature: React native source map fetch mode
     """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The provided API key was invalid." to stdout
-    And the shell has output "HTTP status 401 received from upload API" to stdout
+    And the last run docker command output "The provided API key was invalid."
+    And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" equals "false"
@@ -132,8 +132,8 @@ Feature: React native source map fetch mode
     """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag." to stdout
-    And the shell has output "HTTP status 409 received from upload API" to stdout
+    And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
+    And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" equals "false"
@@ -157,8 +157,8 @@ Feature: React native source map fetch mode
     """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The uploaded source map was empty." to stdout
-    And the shell has output "HTTP status 422 received from upload API" to stdout
+    And the last run docker command output "The uploaded source map was empty."
+    And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" equals "false"
@@ -182,8 +182,8 @@ Feature: React native source map fetch mode
     """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The request was rejected by the server as invalid." to stdout
-    And the shell has output "HTTP status 400 received from upload API" to stdout
+    And the last run docker command output "The request was rejected by the server as invalid."
+    And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" equals "false"

--- a/features/react-native-upload-one.feature
+++ b/features/react-native-upload-one.feature
@@ -12,7 +12,7 @@ Feature: React native source map upload one
       <flags>
     """
     And I wait to receive 1 request
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
@@ -54,7 +54,7 @@ Feature: React native source map upload one
       --platform ios
     """
     And I wait to receive 2 requests
-    Then the exit code is successful
+    Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests

--- a/features/react-native-upload-one.feature
+++ b/features/react-native-upload-one.feature
@@ -75,7 +75,7 @@ Feature: React native source map upload one
       --platform ios
     """
     And I wait to receive 5 requests
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
@@ -98,7 +98,7 @@ Feature: React native source map upload one
       --platform ios
     """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -121,7 +121,7 @@ Feature: React native source map upload one
       --platform ios
     """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -144,7 +144,7 @@ Feature: React native source map upload one
       --platform ios
     """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
@@ -167,7 +167,7 @@ Feature: React native source map upload one
       --platform ios
     """
     And I wait to receive 1 request
-    Then the exit code is not successful
+    Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"

--- a/features/react-native-upload-one.feature
+++ b/features/react-native-upload-one.feature
@@ -76,8 +76,8 @@ Feature: React native source map upload one
     """
     And I wait to receive 5 requests
     Then the exit code is not successful
-    And the shell has output "A server side error occurred while processing the upload." to stdout
-    And the shell has output "HTTP status 500 received from upload API" to stdout
+    And the last run docker command output "A server side error occurred while processing the upload."
+    And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
@@ -99,8 +99,8 @@ Feature: React native source map upload one
     """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The provided API key was invalid." to stdout
-    And the shell has output "HTTP status 401 received from upload API" to stdout
+    And the last run docker command output "The provided API key was invalid."
+    And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" equals "false"
@@ -122,8 +122,8 @@ Feature: React native source map upload one
     """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag." to stdout
-    And the shell has output "HTTP status 409 received from upload API" to stdout
+    And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
+    And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" equals "false"
@@ -145,8 +145,8 @@ Feature: React native source map upload one
     """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The uploaded source map was empty." to stdout
-    And the shell has output "HTTP status 422 received from upload API" to stdout
+    And the last run docker command output "The uploaded source map was empty."
+    And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" equals "false"
@@ -168,8 +168,8 @@ Feature: React native source map upload one
     """
     And I wait to receive 1 request
     Then the exit code is not successful
-    And the shell has output "The request was rejected by the server as invalid." to stdout
-    And the shell has output "HTTP status 400 received from upload API" to stdout
+    And the last run docker command output "The request was rejected by the server as invalid."
+    And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
     And the payload field "overwrite" equals "false"

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -86,17 +86,6 @@ Then("the exit code is not successful") do
   )
 end
 
-Then('the shell has output {string} to stdout') do |expected_line|
-  assert(
-    Docker.output.any? { |line| line.include?(expected_line) },
-    <<~TEXT
-      No line of output included '#{expected_line}'.
-      Full output:
-      #{Docker.output.join("")}
-    TEXT
-  )
-end
-
 Then("the payload field {string} equals {string} for all requests") do |field, expected|
   Server.stored_requests.each_with_index do |request, index|
     actual = read_key_path(request[:body], field)

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -70,14 +70,6 @@ Then("the payload field {string} matches the minified file {string} for {string}
   assert_equal(expected, actual)
 end
 
-Then("the exit code is successful") do
-  assert_equal(
-    Docker.last_exit_code,
-    0,
-    "Expected the last command to exit successfully, but it exited with code #{Docker.last_exit_code}"
-  )
-end
-
 Then("the exit code is not successful") do
   assert_not_equal(
     Docker.last_exit_code,

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -70,14 +70,6 @@ Then("the payload field {string} matches the minified file {string} for {string}
   assert_equal(expected, actual)
 end
 
-Then("the exit code is not successful") do
-  assert_not_equal(
-    Docker.last_exit_code,
-    0,
-    "Expected the last command to exit unsuccessfully, but it exited with code 0"
-  )
-end
-
 Then("the payload field {string} equals {string} for all requests") do |field, expected|
   Server.stored_requests.each_with_index do |request, index|
     actual = read_key_path(request[:body], field)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -16,30 +16,5 @@ AfterConfiguration do |_config|
 end
 
 Before do
-  # This is a bit of a hack to let us record the last command's exit code for
-  # asserting against. This module redefines 'run_docker_compose_command' and then
-  # gets called before the real 'run_docker_compose_command' because it is
-  # prepended (see Module#prepend). This lets us record the last exit code, which
-  # should always be the actual command we run in the tests
-  # There is possibility for tests to interfere with each other, but only if they
-  # don't run commands themselves. In which case, why would they care about the
-  # last exit code??
-  module RecordExitCode
-    attr_reader :output
-    attr_reader :last_exit_code
-
-    def run_docker_compose_command(...)
-      raise "You can't use RecordExitCode without a super class!" unless defined?(super)
-
-      @output, @last_exit_code = super(...)
-    end
-  end
-
-  class Docker
-    class << self
-      prepend RecordExitCode
-    end
-  end
-
   Docker.compose_project_name = "#{rand.to_s}:#{Time.new.strftime("%s")}"
 end


### PR DESCRIPTION
## Goal

Switch back to using the latest Maze Runner release.

## Design

Some new Cucumber steps got implemented in the latest Maze Runner, leading to conflicting names and test failures.  The actual steps needed for the source map tests have also been added to MazeRunner since they were first written, but with different names.  This change switches to using the appropriate steps in MazeRunner 3.6.0 and removes the local implementations (and an associated hack).

## Changeset

MazeRunner docker image, choice of Cucumber steps.

The `--fast-fail` option has also been added to avoid consuming CI resources unnecessarily.  If we want to run a full suite regardless of failures for development purposes we can simply comment these out temporarily.

## Testing

Covered by passing CI.