### PR TITLE
[PLAT-5608]: Automatically add the correct suffix to endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Options
 If you are using Bugsnag On-premise, you should use the endpoint option to set the url of your [upload server](https://docs.bugsnag.com/on-premise/single-machine/service-ports/#bugsnag-upload-server), for example:
 
 ```sh
-# browser/node uploads
 bugsnag-react-native upload-browser \
   --endpoint https://bugsnag.my-company.com/
   # ... other options

--- a/README.md
+++ b/README.md
@@ -46,17 +46,12 @@ Options
 
 ## Bugsnag On-Premise
 
-If you are using Bugsnag On-premise, you should use the endpoint option to set the url of your [upload server](https://docs.bugsnag.com/on-premise/single-machine/service-ports/#bugsnag-upload-server). You must include the correct path, for example:
+If you are using Bugsnag On-premise, you should use the endpoint option to set the url of your [upload server](https://docs.bugsnag.com/on-premise/single-machine/service-ports/#bugsnag-upload-server), for example:
 
 ```sh
 # browser/node uploads
 bugsnag-react-native upload-browser \
-  --endpoint https://bugsnag.my-company.com/source-map \
-  # ... other options
-
-# react native uploads
-bugsnag-react-native upload-react-native \
-  --endpoint https://bugsnag.my-company.com/react-native-source-map \
+  --endpoint https://bugsnag.my-company.com/
   # ... other options
 ```
 

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -12,7 +12,8 @@ import readSourceMap from './lib/ReadSourceMap'
 import parseSourceMap from './lib/ParseSourceMap'
 import _detectAppVersion from './lib/DetectAppVersion'
 
-const UPLOAD_ENDPOINT = 'https://upload.bugsnag.com/source-map'
+import { DEFAULT_UPLOAD_ORIGIN, buildEndpointUrl } from './lib/EndpointUrl'
+const UPLOAD_PATH = '/sourcemap'
 
 interface UploadSingleOpts {
   apiKey: string
@@ -34,12 +35,21 @@ export async function uploadOne ({
   appVersion,
   overwrite = false,
   projectRoot = process.cwd(),
-  endpoint = UPLOAD_ENDPOINT,
+  endpoint = DEFAULT_UPLOAD_ORIGIN,
   detectAppVersion = false,
   requestOpts = {},
   logger = noopLogger
 }: UploadSingleOpts): Promise<void> {
   logger.info(`Preparing upload of node source map for "${bundle}"`)
+
+
+  let url
+  try {
+    url = buildEndpointUrl(endpoint, UPLOAD_PATH)
+  } catch (e) {
+    logger.error(e)
+    throw e
+  }
 
   const [ sourceMapContent, fullSourceMapPath ] = await readSourceMap(sourceMap, projectRoot, logger)
   const [ bundleContent, fullBundlePath ] = await readBundleContent(bundle, projectRoot, sourceMap, logger)
@@ -57,10 +67,10 @@ export async function uploadOne ({
     }
   }
 
-  logger.debug(`Initiating upload to "${endpoint}"`)
+  logger.debug(`Initiating upload to "${url}"`)
   const start = new Date().getTime()
   try {
-    await request(endpoint, {
+    await request(url, {
       type: PayloadType.Node,
       apiKey,
       appVersion,
@@ -69,7 +79,7 @@ export async function uploadOne ({
       sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
       overwrite: overwrite
     }, requestOpts)
-    logger.success(`Success, uploaded ${sourceMap} and ${bundle} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
+    logger.success(`Success, uploaded ${sourceMap} and ${bundle} to ${url} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {
       logger.error(formatErrorLog(e), e, e.cause)
@@ -98,12 +108,21 @@ export async function uploadMultiple ({
   appVersion,
   overwrite = false,
   projectRoot = process.cwd(),
-  endpoint = UPLOAD_ENDPOINT,
+  endpoint = DEFAULT_UPLOAD_ORIGIN,
   detectAppVersion = false,
   requestOpts = {},
   logger = noopLogger
 }: UploadMultipleOpts): Promise<void> {
   logger.info(`Preparing upload of node source maps for "${directory}"`)
+
+  let url
+  try {
+    url = buildEndpointUrl(endpoint, UPLOAD_PATH)
+  } catch (e) {
+    logger.error(e)
+    throw e
+  }
+
   logger.debug(`Searching for source maps "${directory}"`)
   const absoluteSearchPath = path.resolve(projectRoot, directory)
   const sourceMaps: string[] = await new Promise((resolve, reject) => {
@@ -126,7 +145,6 @@ export async function uploadMultiple ({
       appVersion = await _detectAppVersion(projectRoot, logger)
     } catch (e) {
       logger.error(e.message)
-
       throw e
     }
   }
@@ -149,10 +167,10 @@ export async function uploadMultiple ({
 
     const transformedSourceMap = await applyTransformations(fullSourceMapPath, sourceMapJson, projectRoot, logger)
 
-    logger.debug(`Initiating upload to "${endpoint}"`)
+    logger.debug(`Initiating upload to "${url}"`)
     const start = new Date().getTime()
     try {
-      await request(endpoint, {
+      await request(url, {
         type: PayloadType.Node,
         apiKey,
         appVersion,
@@ -164,7 +182,7 @@ export async function uploadMultiple ({
 
       const uploadedFiles = (bundleContent && fullBundlePath) ? `${sourceMap} and ${bundlePath}` : sourceMap
 
-      logger.success(`Success, uploaded ${uploadedFiles} to ${endpoint} in ${(new Date()).getTime() - start}ms`)
+      logger.success(`Success, uploaded ${uploadedFiles} to ${url} in ${(new Date()).getTime() - start}ms`)
     } catch (e) {
       if (e.cause) {
         logger.error(formatErrorLog(e), e, e.cause)

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -29,7 +29,7 @@ test('uploadOne(): dispatches a request with the correct params', async () => {
   })
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       appVersion: '1.2.3',
@@ -54,7 +54,7 @@ test('uploadOne(): dispatches a request with the correct params (no bundle)', as
   })
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       appVersion: '1.2.3',
@@ -302,6 +302,78 @@ test('uploadOne(): failure (timeout)', async () => {
   }
 })
 
+test('uploadOne(): custom endpoint (origin only)', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadOne({
+    endpoint: 'https://bugsnag.my-company.com',
+    apiKey: '123',
+    sourceMap: 'bundle.js.map',
+    bundleUrl: 'http://mybundle.jim',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/a'),
+    logger: mockLogger
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://bugsnag.my-company.com/sourcemap',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedUrl: 'http://mybundle.jim',
+      minifiedFile: expect.any(Object),
+      overwrite: false,
+      sourceMap: expect.any(Object)
+    }),
+    expect.objectContaining({})
+  )
+})
+
+test('uploadOne(): custom endpoint (absolute)', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadOne({
+    endpoint: 'https://bugsnag.my-company.com/source-map-custom',
+    apiKey: '123',
+    sourceMap: 'bundle.js.map',
+    bundleUrl: 'http://mybundle.jim',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/a'),
+    logger: mockLogger
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://bugsnag.my-company.com/source-map-custom',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.any(Object),
+      minifiedUrl: 'http://mybundle.jim',
+      overwrite: false,
+      sourceMap: expect.any(Object)
+    }),
+    expect.objectContaining({})
+  )
+})
+
+test('uploadOne(): custom endpoint (invalid URL)', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  try {
+    await uploadOne({
+      endpoint: 'hljsdf',
+      apiKey: '123',
+      sourceMap: 'bundle.js.map',
+      bundleUrl: 'https://mybundle.jim',
+      bundle: 'bundle.js',
+      projectRoot: path.join(__dirname, 'fixtures/a'),
+      logger: mockLogger
+    })
+    expect(mockedRequest).toHaveBeenCalledTimes(0)
+  } catch (e) {
+    expect(e).toBeTruthy()
+    expect(e.message).toBe('Invalid URL: hljsdf')
+    expect(mockLogger.error).toHaveBeenCalledWith(e)
+  }
+})
+
 test('uploadMultiple(): success with detected appVersion', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
   mockedRequest.mockResolvedValue()
@@ -315,7 +387,7 @@ test('uploadMultiple(): success with detected appVersion', async () => {
   })
   expect(mockedRequest).toHaveBeenCalledTimes(4)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -333,7 +405,7 @@ test('uploadMultiple(): success with detected appVersion', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -351,7 +423,7 @@ test('uploadMultiple(): success with detected appVersion', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -369,7 +441,7 @@ test('uploadMultiple(): success with detected appVersion', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -401,7 +473,7 @@ test('uploadMultiple(): success passing appVersion', async () => {
   })
   expect(mockedRequest).toHaveBeenCalledTimes(4)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -419,7 +491,7 @@ test('uploadMultiple(): success passing appVersion', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -437,7 +509,7 @@ test('uploadMultiple(): success passing appVersion', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -455,7 +527,7 @@ test('uploadMultiple(): success passing appVersion', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -488,7 +560,7 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
 
   expect(mockedRequest).toHaveBeenCalledTimes(4)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -506,7 +578,7 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -524,7 +596,7 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -542,7 +614,7 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({

--- a/src/uploaders/__test__/NodeUploader.test.ts
+++ b/src/uploaders/__test__/NodeUploader.test.ts
@@ -28,7 +28,7 @@ test('uploadOne(): dispatches a request with the correct params', async () => {
   })
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       appVersion: '1.2.3',
@@ -53,7 +53,7 @@ test('uploadOne(): dispatches a request with the correct params and detected app
   })
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       appVersion: '1.2.3',
@@ -163,6 +163,73 @@ test('uploadOne(): failure (sourcemap is invalid json)', async () => {
   }
 })
 
+test('uploadOne(): custom endpoint (origin only)', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadOne({
+    endpoint: 'https://bugsnag.my-company.com',
+    apiKey: '123',
+    sourceMap: 'bundle.js.map',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/a'),
+    logger: mockLogger
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://bugsnag.my-company.com/sourcemap',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.any(Object),
+      overwrite: false,
+      sourceMap: expect.any(Object)
+    }),
+    expect.objectContaining({})
+  )
+})
+
+test('uploadOne(): custom endpoint (absolute)', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadOne({
+    endpoint: 'https://bugsnag.my-company.com/source-map-custom',
+    apiKey: '123',
+    sourceMap: 'bundle.js.map',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/a'),
+    logger: mockLogger
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://bugsnag.my-company.com/source-map-custom',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedUrl: 'bundle.js',
+      overwrite: false,
+      sourceMap: expect.any(Object)
+    }),
+    expect.objectContaining({})
+  )
+})
+
+test('uploadOne(): custom endpoint (invalid URL)', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  try {
+    await uploadOne({
+      endpoint: 'hljsdf',
+      apiKey: '123',
+      sourceMap: 'bundle.js.map',
+      bundle: 'bundle.js',
+      projectRoot: path.join(__dirname, 'fixtures/a'),
+      logger: mockLogger
+    })
+    expect(mockedRequest).toHaveBeenCalledTimes(0)
+  } catch (e) {
+    expect(e).toBeTruthy()
+    expect(e.message).toBe('Invalid URL: hljsdf')
+    expect(mockLogger.error).toHaveBeenCalledWith(e)
+  }
+})
+
 test('uploadMultiple(): success', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
   mockedRequest.mockResolvedValue()
@@ -175,7 +242,7 @@ test('uploadMultiple(): success', async () => {
   })
   expect(mockedRequest).toHaveBeenCalledTimes(3)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -193,7 +260,7 @@ test('uploadMultiple(): success', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -211,7 +278,7 @@ test('uploadMultiple(): success', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -242,7 +309,7 @@ test('uploadMultiple(): success with detected appVersion', async () => {
   })
   expect(mockedRequest).toHaveBeenCalledTimes(4)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -260,7 +327,7 @@ test('uploadMultiple(): success with detected appVersion', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -278,7 +345,7 @@ test('uploadMultiple(): success with detected appVersion', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -296,7 +363,7 @@ test('uploadMultiple(): success with detected appVersion', async () => {
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -327,7 +394,7 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
   })
   expect(mockedRequest).toHaveBeenCalledTimes(3)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -345,7 +412,7 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({
@@ -363,7 +430,7 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
     expect.objectContaining({})
   )
   expect(mockedRequest).toHaveBeenCalledWith(
-    'https://upload.bugsnag.com/source-map',
+    'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({
       apiKey: '123',
       minifiedFile: expect.objectContaining({

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -23,7 +23,6 @@ test('uploadOne(): dispatches a request with the correct params for Android with
   mockedRequest.mockResolvedValue()
 
   await uploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -36,7 +35,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -55,7 +54,6 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
   mockedRequest.mockResolvedValue()
 
   await uploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -68,7 +66,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -87,7 +85,6 @@ test('uploadOne(): dispatches a request with the correct params for Android with
   mockedRequest.mockResolvedValue()
 
   await uploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -101,7 +98,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -121,7 +118,6 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
   mockedRequest.mockResolvedValue()
 
   await uploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -135,7 +131,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -155,7 +151,6 @@ test('uploadOne(): dispatches a request with the correct params for Android with
   mockedRequest.mockResolvedValue()
 
   await uploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -169,7 +164,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -189,7 +184,6 @@ test('uploadOne(): dispatches a request with the correct params for iOS with cod
   mockedRequest.mockResolvedValue()
 
   await uploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -203,7 +197,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with cod
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -228,7 +222,7 @@ test('uploadOne(): failure (unexpected network error) with cause', async () => {
 
   try {
     await uploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: false,
@@ -261,7 +255,7 @@ test('uploadOne(): failure (unexpected network error) without cause', async () =
 
   try {
     await uploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: false,
@@ -291,7 +285,7 @@ test('uploadOne(): failure (source map not found)', async () => {
 
   try {
     await uploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: false,
@@ -312,6 +306,57 @@ test('uploadOne(): failure (source map not found)', async () => {
   }
 })
 
+test('uploadOne(): custom endpoint (absolute)', async () => {
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  await uploadOne({
+    endpoint: 'https://bugsnag.my-company.com/source-map-custom',
+    apiKey: '123',
+    overwrite: false,
+    dev: false,
+    platform: 'ios',
+    appBundleVersion: '4.5.6',
+    sourceMap: 'bundle.js.map',
+    bundle: 'bundle.js',
+    codeBundleId: '1.2.3',
+    projectRoot: path.join(__dirname, 'fixtures/react-native-ios'),
+    logger: mockLogger
+  })
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://bugsnag.my-company.com/source-map-custom',
+    expect.objectContaining({ apiKey: '123' }),
+    expect.objectContaining({})
+  )
+})
+
+test('uploadOne(): custom endpoint (invalid URL)', async () => {
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+
+  try {
+    await uploadOne({
+      endpoint: 'hljsdf',
+      apiKey: '123',
+      overwrite: false,
+      dev: false,
+      platform: 'ios',
+      appBundleVersion: '4.5.6',
+      sourceMap: 'bundle.js.map',
+      bundle: 'bundle.js',
+      codeBundleId: '1.2.3',
+      projectRoot: path.join(__dirname, 'fixtures/react-native-ios'),
+      logger: mockLogger
+    })
+    expect(mockedRequest).toHaveBeenCalledTimes(0)
+  } catch (e) {
+    expect(e).toBeTruthy()
+    expect(e.message).toBe('Invalid URL: hljsdf')
+    expect(mockLogger.error).toHaveBeenCalledWith(e)
+  }
+})
+
 test('fetchAndUploadOne(): dispatches a request with the correct params for Android with appVersion in Fetch mode', async () => {
   const directory = path.join(__dirname, 'fixtures/react-native-android')
   const sourceMap = await fs.readFile(path.resolve(directory, 'bundle.js.map'))
@@ -325,7 +370,6 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
   mockedRequest.mockResolvedValue()
 
   await fetchAndUploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -343,7 +387,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -357,7 +401,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
-    'Success, uploaded index.js.map to example.com in'
+    'Success, uploaded index.js.map to '
   ))
 })
 
@@ -374,7 +418,6 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
   mockedRequest.mockResolvedValue()
 
   await fetchAndUploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -391,7 +434,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -405,7 +448,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
-    'Success, uploaded index.js.map to example.com in'
+    'Success, uploaded index.js.map to '
   ))
 })
 
@@ -422,7 +465,6 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
   mockedRequest.mockResolvedValue()
 
   await fetchAndUploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: true,
@@ -438,7 +480,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -465,7 +507,6 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
   mockedRequest.mockResolvedValue()
 
   await fetchAndUploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: true,
@@ -481,7 +522,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -508,7 +549,6 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   mockedRequest.mockResolvedValue()
 
   await fetchAndUploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -526,7 +566,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -540,7 +580,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
-    'Success, uploaded cool-app.js.map to example.com in'
+    'Success, uploaded cool-app.js.map to '
   ))
 })
 
@@ -557,7 +597,6 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   mockedRequest.mockResolvedValue()
 
   await fetchAndUploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -575,7 +614,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -589,7 +628,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
-    'Success, uploaded cool-app.js.map to example.com in'
+    'Success, uploaded cool-app.js.map to '
   ))
 })
 
@@ -606,7 +645,6 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   mockedRequest.mockResolvedValue()
 
   await fetchAndUploadOne({
-    endpoint: 'example.com',
     apiKey: '123',
     overwrite: false,
     dev: false,
@@ -624,7 +662,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
-    'example.com',
+    'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
       overwrite: false,
@@ -638,7 +676,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
-    'Success, uploaded cool-app.js.map to example.com in'
+    'Success, uploaded cool-app.js.map to '
   ))
 })
 
@@ -653,7 +691,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (generic Error)'
 
   try {
     await fetchAndUploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: true,
@@ -685,7 +723,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (generic Network
 
   try {
     await fetchAndUploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: true,
@@ -719,7 +757,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (connection refu
 
   try {
     await fetchAndUploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: true,
@@ -753,7 +791,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (server error)',
 
   try {
     await fetchAndUploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: true,
@@ -787,7 +825,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (timeout)', asyn
 
   try {
     await fetchAndUploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: true,
@@ -823,7 +861,7 @@ test('fethchAndUploadOne(): Fetch mode failure to get bundle (generic Error)', a
 
   try {
     await fetchAndUploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: true,
@@ -860,7 +898,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (generic NetworkErro
 
   try {
     await fetchAndUploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: true,
@@ -899,7 +937,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (connection refused)
 
   try {
     await fetchAndUploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: true,
@@ -938,7 +976,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (server error)', asy
 
   try {
     await fetchAndUploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: true,
@@ -977,7 +1015,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (timeout)', async ()
 
   try {
     await fetchAndUploadOne({
-      endpoint: 'example.com',
+      endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
       overwrite: false,
       dev: true,

--- a/src/uploaders/lib/EndpointUrl.ts
+++ b/src/uploaders/lib/EndpointUrl.ts
@@ -2,7 +2,11 @@ export const DEFAULT_UPLOAD_ORIGIN = 'https://upload.bugsnag.com'
 
 export function buildEndpointUrl (origin: string, path: string): string {
   const url = new URL(origin)
-  // if more than a full origin was given, use the provided URL as-is
-  if (url.pathname !== '/') return url.toString()
-  return new URL(path, origin).toString()
+  
+  // if no path was given use the default
+  if (url.pathname === '/') {
+    url.pathname = path
+  }
+
+  return url.toString()
 }

--- a/src/uploaders/lib/EndpointUrl.ts
+++ b/src/uploaders/lib/EndpointUrl.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_UPLOAD_ORIGIN = 'https://upload.bugsnag.com'
+
+export function buildEndpointUrl (origin: string, path: string): string {
+  const url = new URL(origin)
+  // if more than a full origin was given, use the provided URL as-is
+  if (url.pathname !== '/') return url.toString()
+  return new URL(path, origin).toString()
+}


### PR DESCRIPTION
## Goal

Only accepting the full/absolute URL meant that On-Premise needed to know unecessary detail about the different paths on the upload server, and also meant some commands were unnecessarily repetitive:

```
bugsnag-source-maps upload-react-native --endpoint https://bugsnag.my-company.com/react-native-source-map ...
```

## Design

Based on the kind of source map being uploaded (which we know becuase there is a separate command/library for each) we can predict what the path of the URL is: either `/sourcemap`¹ or `/react-native-source-map`

¹ the path `/source-map` exists (which is correctly named) but for now we use `/sourcemap` – it has existed for longer so supports older On-Premise versions.

## Changeset

- Added a small utility to build the full endpoint URL
- Ensured backward compatibility is maintained (e.g. if the `--endpoint` provided includes a path longer than `/`, it will use that verbatim)

## Testing

Updated unit tests.