### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.0 (2021-01-21)
+
+- Default `overwrite=true` for React Native uploads [#50](https://github.com/bugsnag/bugsnag-source-maps/pull/50)
+- Remove `--overwrite` flag from React Native uploads command and add `--no-overwrite` [#50](https://github.com/bugsnag/bugsnag-source-maps/pull/50)
+
 # 1.0.1 (2020-12-14)
 
 - Automatically set an appropriate path on the endpoint URL unless one is explicitly provided [#48](https://github.com/bugsnag/bugsnag-source-maps/pull/48)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
-# 2.0.0 (2021-01-21)
+# Changelog
 
-- Default `overwrite=true` for React Native uploads [#50](https://github.com/bugsnag/bugsnag-source-maps/pull/50)
+## 2.0.0 (2021-01-21)
+
+## Breaking
+
+- Default `overwrite=true` for React Native upload [#50](https://github.com/bugsnag/bugsnag-source-maps/pull/50)
 - Remove `--overwrite` flag from React Native uploads command and add `--no-overwrite` [#50](https://github.com/bugsnag/bugsnag-source-maps/pull/50)
 
-# 1.0.1 (2020-12-14)
+Note: using the `--overwrite` option with the `upload-react-native` command will now fail because the flag has been removed.
+
+## 1.0.1 (2020-12-14)
+
+## Changed
 
 - Automatically set an appropriate path on the endpoint URL unless one is explicitly provided [#48](https://github.com/bugsnag/bugsnag-source-maps/pull/48)
 
-# 1.0.0 (2020-12-10)
+## 1.0.0 (2020-12-10)
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Options
 If you are using Bugsnag On-premise, you should use the endpoint option to set the url of your [upload server](https://docs.bugsnag.com/on-premise/single-machine/service-ports/#bugsnag-upload-server), for example:
 
 ```sh
-bugsnag-react-native upload-browser \
+bugsnag-source-maps upload-browser \
   --endpoint https://bugsnag.my-company.com/
   # ... other options
 ```

--- a/features/react-native-fetch.feature
+++ b/features/react-native-fetch.feature
@@ -18,7 +18,7 @@ Feature: React native source map fetch mode
     And the Content-Type header is valid multipart form-data
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"
     And the payload field "dev" equals "<dev>"
     And the payload field "platform" equals "<platform>"
     And the payload field "sourceMap" matches the expected source map for "<expected directory>"
@@ -62,7 +62,7 @@ Feature: React native source map fetch mode
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" equals "false" for all requests
+    And the payload field "overwrite" equals "true" for all requests
     And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios" for all requests
     And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios" for all requests
 
@@ -87,7 +87,7 @@ Feature: React native source map fetch mode
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" equals "false" for all requests
+    And the payload field "overwrite" equals "true" for all requests
     And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios" for all requests
     And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios" for all requests
 
@@ -111,7 +111,7 @@ Feature: React native source map fetch mode
     And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"
     And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
     And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
@@ -132,11 +132,11 @@ Feature: React native source map fetch mode
     """
     And I wait to receive 1 request
     Then the last run docker command did not exit successfully
-    And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
+    And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, remove the \"no-overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"
     And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
     And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
@@ -161,7 +161,7 @@ Feature: React native source map fetch mode
     And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"
     And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
     And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
@@ -186,7 +186,7 @@ Feature: React native source map fetch mode
     And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"
     And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
     And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data

--- a/features/react-native-upload-one.feature
+++ b/features/react-native-upload-one.feature
@@ -16,7 +16,7 @@ Feature: React native source map upload one
     And the Content-Type header is valid multipart form-data
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"
     And the payload field "dev" equals "<dev>"
     And the payload field "platform" equals "<platform>"
     And the payload field "sourceMap" matches the expected source map for "<service>"
@@ -58,7 +58,7 @@ Feature: React native source map upload one
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" equals "false" for all requests
+    And the payload field "overwrite" equals "true" for all requests
     And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios" for all requests
     And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios" for all requests
 
@@ -81,7 +81,7 @@ Feature: React native source map upload one
     And the Content-Type header is valid multipart form-data for all requests
     And the payload field "apiKey" equals "123" for all requests
     And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" equals "false" for all requests
+    And the payload field "overwrite" equals "true" for all requests
     And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios" for all requests
     And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios" for all requests
 
@@ -103,7 +103,7 @@ Feature: React native source map upload one
     And the last run docker command output "HTTP status 401 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"
     And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
     And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
@@ -122,11 +122,11 @@ Feature: React native source map upload one
     """
     And I wait to receive 1 request
     Then the last run docker command did not exit successfully
-    And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
+    And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, remove the \"no-overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"
     And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
     And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
@@ -149,7 +149,7 @@ Feature: React native source map upload one
     And the last run docker command output "HTTP status 422 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"
     And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
     And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
@@ -172,7 +172,7 @@ Feature: React native source map upload one
     And the last run docker command output "HTTP status 400 received from upload API"
     And the payload field "apiKey" equals "123"
     And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "false"
+    And the payload field "overwrite" equals "true"
     And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
     And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -11,7 +11,7 @@ export default async function uploadReactNative (argv: string[], opts: Record<st
   }
 
   const defs: OptionDefinition[] = [
-    ...commonCommandDefs,
+    ...commonCommandDefs.filter(def => def.name !== 'overwrite'),
     ...reactNativeCommonDefs,
     ...reactNativeProvideOpts,
     ...reactNativeFetchOpts,
@@ -44,7 +44,7 @@ export default async function uploadReactNative (argv: string[], opts: Record<st
       await fetchAndUploadOne({
         apiKey: reactNativeOpts.apiKey,
         projectRoot: reactNativeOpts.projectRoot,
-        overwrite: reactNativeOpts.overwrite,
+        overwrite: !reactNativeOpts.noOverwrite,
         appVersion: reactNativeOpts.appVersion,
         codeBundleId: reactNativeOpts.codeBundleId,
         appBundleVersion: reactNativeOpts.appBundleVersion,
@@ -62,7 +62,7 @@ export default async function uploadReactNative (argv: string[], opts: Record<st
         sourceMap: reactNativeOpts.sourceMap,
         bundle: reactNativeOpts.bundle,
         projectRoot: reactNativeOpts.projectRoot,
-        overwrite: reactNativeOpts.overwrite,
+        overwrite: !reactNativeOpts.noOverwrite,
         appVersion: reactNativeOpts.appVersion,
         codeBundleId: reactNativeOpts.codeBundleId,
         appBundleVersion: reactNativeOpts.appBundleVersion,
@@ -131,6 +131,11 @@ const reactNativeCommonDefs = [
     type: Boolean,
     description: 'indicates this is a debug build',
   },
+  {
+    name: 'no-overwrite',
+    type: Boolean,
+    description: 'prevent exiting source maps uploaded with the same version from being replaced'
+  }
 ]
 
 const reactNativeProvideOpts = [

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -45,7 +45,7 @@ export async function uploadOne ({
   codeBundleId,
   appVersionCode,
   appBundleVersion,
-  overwrite = false,
+  overwrite = true,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
   requestOpts = {},
@@ -85,9 +85,9 @@ export async function uploadOne ({
     logger.success(`Success, uploaded ${sourceMap} and ${bundle} to ${url} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {
-      logger.error(formatErrorLog(e), e, e.cause)
+      logger.error(formatErrorLog(e, true), e, e.cause)
     } else {
-      logger.error(formatErrorLog(e), e)
+      logger.error(formatErrorLog(e, true), e)
     }
     throw e
   }
@@ -106,7 +106,7 @@ export async function fetchAndUploadOne ({
   codeBundleId,
   appVersionCode,
   appBundleVersion,
-  overwrite = false,
+  overwrite = true,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
   requestOpts = {},
@@ -176,9 +176,9 @@ export async function fetchAndUploadOne ({
     logger.success(`Success, uploaded ${entryPoint}.js.map to ${url} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {
-      logger.error(formatErrorLog(e), e, e.cause)
+      logger.error(formatErrorLog(e, true), e, e.cause)
     } else {
-      logger.error(formatErrorLog(e), e)
+      logger.error(formatErrorLog(e, true), e)
     }
     throw e
   }

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -253,7 +253,12 @@ test('uploadOne(): failure (duplicate)', async () => {
   } catch (e) {
     expect(e).toBeTruthy()
     expect((e as NetworkError).code).toBe(NetworkErrorCode.DUPLICATE)
-    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('A source map matching the same criteria has already been uploaded. If you want to replace it, use the "overwrite" flag'), expect.any(Error))
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'A source map matching the same criteria has already been uploaded. If you want to replace it, use the "overwrite" flag.'
+        ),
+        expect.any(Error)
+      )
   }
 })
 

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -24,7 +24,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
 
   await uploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'android',
     sourceMap: 'bundle.js.map',
@@ -38,7 +38,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'android',
       appVersion: '1.2.3',
@@ -55,7 +55,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
 
   await uploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'ios',
     sourceMap: 'bundle.js.map',
@@ -69,7 +69,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       appVersion: '1.2.3',
@@ -86,7 +86,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
 
   await uploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'android',
     appVersionCode: '3.2.1',
@@ -101,7 +101,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'android',
       appVersionCode: '3.2.1',
@@ -119,7 +119,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
 
   await uploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'ios',
     appBundleVersion: '4.5.6',
@@ -134,7 +134,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       appBundleVersion: '4.5.6',
@@ -152,7 +152,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
 
   await uploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'android',
     appVersionCode: '3.2.1', // We provide this but it should be ignored!
@@ -167,7 +167,7 @@ test('uploadOne(): dispatches a request with the correct params for Android with
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'android',
       codeBundleId: '1.2.3',
@@ -185,7 +185,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with cod
 
   await uploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'ios',
     appBundleVersion: '4.5.6', // We provide this but it should be ignored!
@@ -200,7 +200,7 @@ test('uploadOne(): dispatches a request with the correct params for iOS with cod
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       codeBundleId: '1.2.3',
@@ -224,7 +224,7 @@ test('uploadOne(): failure (unexpected network error) with cause', async () => {
     await uploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       appBundleVersion: '4.5.6',
@@ -257,7 +257,7 @@ test('uploadOne(): failure (unexpected network error) without cause', async () =
     await uploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       appBundleVersion: '4.5.6',
@@ -287,7 +287,7 @@ test('uploadOne(): failure (source map not found)', async () => {
     await uploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       appBundleVersion: '4.5.6',
@@ -313,7 +313,7 @@ test('uploadOne(): custom endpoint (absolute)', async () => {
   await uploadOne({
     endpoint: 'https://bugsnag.my-company.com/source-map-custom',
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'ios',
     appBundleVersion: '4.5.6',
@@ -339,7 +339,7 @@ test('uploadOne(): custom endpoint (invalid URL)', async () => {
     await uploadOne({
       endpoint: 'hljsdf',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       appBundleVersion: '4.5.6',
@@ -371,7 +371,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
 
   await fetchAndUploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'android',
     bundlerUrl: 'http://react-native-bundler:1234',
@@ -390,7 +390,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'android',
       appVersion: '1.2.3',
@@ -419,7 +419,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
 
   await fetchAndUploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'ios',
     bundlerUrl: 'http://react-native-bundler:1234',
@@ -437,7 +437,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       appVersion: '1.2.3',
@@ -466,7 +466,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
 
   await fetchAndUploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: true,
     platform: 'android',
     bundlerUrl: 'http://react-native-bundler:1234',
@@ -483,7 +483,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       appVersion: '1.2.3',
@@ -508,7 +508,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
 
   await fetchAndUploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: true,
     platform: 'ios',
     bundlerUrl: 'http://react-native-bundler:1234',
@@ -525,7 +525,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'ios',
       appVersion: '1.2.3',
@@ -550,7 +550,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
 
   await fetchAndUploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'ios',
     bundlerUrl: 'http://react-native-bundler:1234',
@@ -569,7 +569,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       appVersion: '1.2.3',
@@ -598,7 +598,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
 
   await fetchAndUploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'ios',
     bundlerUrl: 'http://react-native-bundler:1234',
@@ -617,7 +617,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       appVersion: '1.2.3',
@@ -646,7 +646,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
 
   await fetchAndUploadOne({
     apiKey: '123',
-    overwrite: false,
+    overwrite: true,
     dev: false,
     platform: 'ios',
     bundlerUrl: 'http://react-native-bundler:1234',
@@ -665,7 +665,7 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
     'https://upload.bugsnag.com/react-native-source-map',
     expect.objectContaining({
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: false,
       platform: 'ios',
       appVersion: '1.2.3',
@@ -693,7 +693,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (generic Error)'
     await fetchAndUploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       bundlerUrl: 'http://react-native-bundler:1234',
@@ -725,7 +725,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (generic Network
     await fetchAndUploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       bundlerUrl: 'http://react-native-bundler:1234',
@@ -759,7 +759,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (connection refu
     await fetchAndUploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       bundlerUrl: 'http://react-native-bundler:1234',
@@ -793,7 +793,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (server error)',
     await fetchAndUploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       bundlerUrl: 'http://react-native-bundler:1234',
@@ -827,7 +827,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (timeout)', asyn
     await fetchAndUploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       bundlerUrl: 'http://react-native-bundler:1234',
@@ -863,7 +863,7 @@ test('fethchAndUploadOne(): Fetch mode failure to get bundle (generic Error)', a
     await fetchAndUploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       bundlerUrl: 'http://react-native-bundler:1234',
@@ -900,7 +900,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (generic NetworkErro
     await fetchAndUploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       bundlerUrl: 'http://react-native-bundler:1234',
@@ -939,7 +939,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (connection refused)
     await fetchAndUploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       bundlerUrl: 'http://react-native-bundler:1234',
@@ -978,7 +978,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (server error)', asy
     await fetchAndUploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       bundlerUrl: 'http://react-native-bundler:1234',
@@ -1017,7 +1017,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (timeout)', async ()
     await fetchAndUploadOne({
       endpoint: 'https://upload.bugsnag.com/react-native-source-map',
       apiKey: '123',
-      overwrite: false,
+      overwrite: true,
       dev: true,
       platform: 'android',
       bundlerUrl: 'http://react-native-bundler:1234',

--- a/src/uploaders/lib/FormatErrorLog.ts
+++ b/src/uploaders/lib/FormatErrorLog.ts
@@ -1,6 +1,6 @@
 import { NetworkErrorCode, NetworkError } from '../../NetworkError'
 
-function formatErrorLog (e: NetworkError): string {
+function formatErrorLog (e: NetworkError, isReactNative?: boolean): string {
   let str = ''
   switch (e.code) {
     case NetworkErrorCode.EMPTY_FILE:
@@ -14,7 +14,9 @@ function formatErrorLog (e: NetworkError): string {
       str += `\n\n  responseText = ${e.responseText}`
       break
     case NetworkErrorCode.DUPLICATE:
-      str += 'A source map matching the same criteria has already been uploaded. If you want to replace it, use the "overwrite" flag.'
+      str += !isReactNative
+        ? 'A source map matching the same criteria has already been uploaded. If you want to replace it, use the "overwrite" flag.'
+        : 'A source map matching the same criteria has already been uploaded. If you want to replace it, remove the "no-overwrite" flag.'
       break
     case NetworkErrorCode.SERVER_ERROR:
       str += 'A server side error occurred while processing the upload.'


### PR DESCRIPTION
## 2.0.0 (2021-01-21)

## Breaking

- Default `overwrite=true` for React Native upload [#50](https://github.com/bugsnag/bugsnag-source-maps/pull/50)
- Remove `--overwrite` flag from React Native uploads command and add `--no-overwrite` [#50](https://github.com/bugsnag/bugsnag-source-maps/pull/50)

Note: using the `--overwrite` option with the `upload-react-native` command will now fail because the flag has been removed.