### PR TITLE
feat: Add input validation for use as a JS library

### DIFF
--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -11,6 +11,13 @@ import readBundleContent from './lib/ReadBundleContent'
 import readSourceMap from './lib/ReadSourceMap'
 import parseSourceMap from './lib/ParseSourceMap'
 import _detectAppVersion from './lib/DetectAppVersion'
+import {
+  validateRequiredStrings,
+  validateOptionalStrings,
+  validateBooleans,
+  validateObjects,
+  validateNoUnknownArgs
+} from './lib/InputValidators'
 
 import { DEFAULT_UPLOAD_ORIGIN, buildEndpointUrl } from './lib/EndpointUrl'
 const UPLOAD_PATH = '/sourcemap'
@@ -30,6 +37,14 @@ interface UploadSingleOpts {
   logger?: Logger
 }
 
+function validateOneOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
+  validateRequiredStrings(opts, [ 'apiKey', 'sourceMap', 'bundleUrl', 'projectRoot', 'endpoint' ])
+  validateOptionalStrings(opts, [ 'bundle', 'appVersion', 'codeBundleId' ])
+  validateBooleans(opts, [ 'overwrite', 'detectAppVersion' ])
+  validateObjects(opts, [ 'requestOpts', 'logger' ])
+  validateNoUnknownArgs(unknownArgs)
+}
+
 export async function uploadOne ({
   apiKey,
   bundleUrl,
@@ -42,8 +57,24 @@ export async function uploadOne ({
   endpoint = DEFAULT_UPLOAD_ORIGIN,
   detectAppVersion = false,
   requestOpts = {},
-  logger = noopLogger
+  logger = noopLogger,
+  ...unknownArgs
 }: UploadSingleOpts): Promise<void> {
+  validateOneOpts({
+    apiKey,
+    bundleUrl,
+    bundle,
+    sourceMap,
+    appVersion,
+    codeBundleId,
+    overwrite,
+    projectRoot,
+    endpoint,
+    detectAppVersion,
+    requestOpts,
+    logger
+  }, unknownArgs as Record<string, unknown>)
+
   logger.info(`Preparing upload of browser source map for "${bundleUrl}"`)
 
   let url
@@ -114,6 +145,15 @@ interface UploadMultipleOpts {
   logger?: Logger
 }
 
+
+function validateMultipleOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
+  validateRequiredStrings(opts, [ 'apiKey', 'baseUrl', 'directory', 'projectRoot', 'endpoint' ])
+  validateOptionalStrings(opts, [ 'appVersion' ])
+  validateBooleans(opts, [ 'overwrite', 'detectAppVersion' ])
+  validateObjects(opts, [ 'requestOpts', 'logger' ])
+  validateNoUnknownArgs(unknownArgs)
+}
+
 export async function uploadMultiple ({
   apiKey,
   baseUrl,
@@ -124,8 +164,22 @@ export async function uploadMultiple ({
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
   requestOpts = {},
-  logger = noopLogger
+  logger = noopLogger,
+  ...unknownArgs
 }: UploadMultipleOpts): Promise<void> {
+  validateMultipleOpts({
+    apiKey,
+    baseUrl,
+    directory,
+    appVersion,
+    overwrite,
+    projectRoot,
+    endpoint,
+    detectAppVersion,
+    requestOpts,
+    logger
+  }, unknownArgs as Record<string, unknown>)
+
   logger.info(`Preparing upload of browser source maps for "${baseUrl}"`)
 
   let url

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -11,6 +11,13 @@ import readBundleContent from './lib/ReadBundleContent'
 import readSourceMap from './lib/ReadSourceMap'
 import parseSourceMap from './lib/ParseSourceMap'
 import _detectAppVersion from './lib/DetectAppVersion'
+import {
+  validateRequiredStrings,
+  validateOptionalStrings,
+  validateBooleans,
+  validateObjects,
+  validateNoUnknownArgs
+} from './lib/InputValidators'
 
 import { DEFAULT_UPLOAD_ORIGIN, buildEndpointUrl } from './lib/EndpointUrl'
 const UPLOAD_PATH = '/sourcemap'
@@ -28,6 +35,14 @@ interface UploadSingleOpts {
   logger?: Logger
 }
 
+function validateOneOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
+  validateRequiredStrings(opts, [ 'apiKey', 'sourceMap', 'projectRoot', 'endpoint' ])
+  validateOptionalStrings(opts, [ 'bundle', 'appVersion' ])
+  validateBooleans(opts, [ 'overwrite', 'detectAppVersion' ])
+  validateObjects(opts, [ 'requestOpts', 'logger' ])
+  validateNoUnknownArgs(unknownArgs)
+}
+
 export async function uploadOne ({
   apiKey,
   bundle,
@@ -38,10 +53,23 @@ export async function uploadOne ({
   endpoint = DEFAULT_UPLOAD_ORIGIN,
   detectAppVersion = false,
   requestOpts = {},
-  logger = noopLogger
+  logger = noopLogger,
+  ...unknownArgs
 }: UploadSingleOpts): Promise<void> {
-  logger.info(`Preparing upload of node source map for "${bundle}"`)
+  validateOneOpts({
+    apiKey,
+    bundle,
+    sourceMap,
+    appVersion,
+    overwrite,
+    projectRoot,
+    endpoint,
+    detectAppVersion,
+    requestOpts,
+    logger
+  }, unknownArgs as Record<string, unknown>)
 
+  logger.info(`Preparing upload of node source map for "${bundle}"`)
 
   let url
   try {
@@ -102,6 +130,14 @@ interface UploadMultipleOpts {
   logger?: Logger
 }
 
+function validateMultipleOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
+  validateRequiredStrings(opts, [ 'apiKey', 'directory', 'projectRoot', 'endpoint' ])
+  validateOptionalStrings(opts, [ 'appVersion' ])
+  validateBooleans(opts, [ 'overwrite', 'detectAppVersion' ])
+  validateObjects(opts, [ 'requestOpts', 'logger' ])
+  validateNoUnknownArgs(unknownArgs)
+}
+
 export async function uploadMultiple ({
   apiKey,
   directory,
@@ -111,8 +147,21 @@ export async function uploadMultiple ({
   endpoint = DEFAULT_UPLOAD_ORIGIN,
   detectAppVersion = false,
   requestOpts = {},
-  logger = noopLogger
+  logger = noopLogger,
+  ...unknownArgs
 }: UploadMultipleOpts): Promise<void> {
+  validateMultipleOpts({
+    apiKey,
+    directory,
+    appVersion,
+    overwrite,
+    projectRoot,
+    endpoint,
+    detectAppVersion,
+    requestOpts,
+    logger
+  }, unknownArgs as Record<string, unknown>)
+
   logger.info(`Preparing upload of node source maps for "${directory}"`)
 
   let url

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -11,6 +11,13 @@ import readBundleContent from './lib/ReadBundleContent'
 import readSourceMap from './lib/ReadSourceMap'
 import parseSourceMap from './lib/ParseSourceMap'
 import { NetworkError, NetworkErrorCode } from '../NetworkError'
+import {
+  validateRequiredStrings,
+  validateOptionalStrings,
+  validateBooleans,
+  validateObjects,
+  validateNoUnknownArgs
+} from './lib/InputValidators'
 
 import { DEFAULT_UPLOAD_ORIGIN, buildEndpointUrl } from './lib/EndpointUrl'
 const UPLOAD_PATH = '/react-native-source-map'
@@ -35,6 +42,14 @@ interface UploadSingleOpts extends CommonUploadOpts {
   bundle: string
 }
 
+function validateOneOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
+  validateRequiredStrings(opts, [ 'apiKey', 'sourceMap', 'projectRoot', 'endpoint', 'platform' ])
+  validateOptionalStrings(opts, [ 'bundle', 'appVersion', 'codeBundleId', 'appVersionCode', 'appBundleVersion' ])
+  validateBooleans(opts, [ 'overwrite', 'dev' ])
+  validateObjects(opts, [ 'requestOpts', 'logger' ])
+  validateNoUnknownArgs(unknownArgs)
+}
+
 export async function uploadOne ({
   apiKey,
   sourceMap,
@@ -49,8 +64,26 @@ export async function uploadOne ({
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
   requestOpts = {},
-  logger = noopLogger
+  logger = noopLogger,
+  ...unknownArgs
 }: UploadSingleOpts): Promise<void> {
+  validateOneOpts({
+    apiKey,
+    sourceMap,
+    bundle,
+    platform,
+    dev,
+    appVersion,
+    codeBundleId,
+    appVersionCode,
+    appBundleVersion,
+    overwrite,
+    projectRoot,
+    endpoint,
+    requestOpts,
+    logger
+  }, unknownArgs as Record<string, unknown>)
+
   logger.info(`Preparing upload of React Native source map (${dev ? 'dev' : 'release'} / ${platform})`)
 
   let url
@@ -98,6 +131,14 @@ interface FetchUploadOpts extends CommonUploadOpts {
   bundlerEntryPoint?: string
 }
 
+function validateFetchOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
+  validateRequiredStrings(opts, [ 'apiKey', 'projectRoot', 'endpoint', 'platform', 'bundlerUrl', 'bundlerEntryPoint' ])
+  validateOptionalStrings(opts, [ 'bundle', 'appVersion', 'codeBundleId', 'appVersionCode', 'appBundleVersion' ])
+  validateBooleans(opts, [ 'overwrite', 'dev' ])
+  validateObjects(opts, [ 'requestOpts', 'logger' ])
+  validateNoUnknownArgs(unknownArgs)
+}
+
 export async function fetchAndUploadOne ({
   apiKey,
   platform,
@@ -112,8 +153,26 @@ export async function fetchAndUploadOne ({
   requestOpts = {},
   bundlerUrl = 'http://localhost:8081',
   bundlerEntryPoint = 'index.js',
-  logger = noopLogger
+  logger = noopLogger,
+  ...unknownArgs
 }: FetchUploadOpts): Promise<void> {
+  validateFetchOpts({
+    apiKey,
+    platform,
+    dev,
+    appVersion,
+    codeBundleId,
+    appVersionCode,
+    appBundleVersion,
+    overwrite,
+    projectRoot,
+    endpoint,
+    requestOpts,
+    bundlerUrl,
+    bundlerEntryPoint,
+    logger
+  }, unknownArgs as Record<string, unknown>)
+
   logger.info(`Fetching React Native source map (${dev ? 'dev' : 'release'} / ${platform})`)
 
   let url

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -746,3 +746,42 @@ test('uploadMultiple(): failure (connection error)', async () => {
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('An unexpected error occurred'), expect.any(Error), expect.any(Error))
   }
 })
+
+describe('input validation errors (when using as a JS library', () => {
+  test.each([
+    [ {}, 'apiKey is required and must be a string' ],
+    [ { apiKey: 123 }, 'apiKey is required and must be a string' ],
+    [ { apiKey: '123' }, 'sourceMap is required and must be a string' ],
+    [ { apiKey: '123', sourceMap: 'm.map' }, 'bundleUrl is required and must be a string' ],
+    [ { apiKey: '123', sourceMap: 'm.map', bundleUrl: 'j.js', appVersion: 1 }, 'appVersion must be a string' ],
+    [ { apiKey: '123', sourceMap: 'm.map', bundleUrl: 'j.js', logger: null }, 'logger must be an object' ],
+    [ { apiKey: '123', sourceMap: 'm.map', bundleUrl: 'j.js', overwrite: 'yes' }, 'overwrite must be true or false' ],
+    [ { apiKey: '123', sourceMap: 'm.map', bundleUrl: 'j.js', somethingDifferent: 'yes' }, 'Unrecognized option(s): somethingDifferent' ],
+    [
+      { apiKey: '123', sourceMap: 'm.map', bundleUrl: 'j.js', somethingDifferent: 'yes', somethingElse: 'no' },
+      'Unrecognized option(s): somethingDifferent, somethingElse'
+    ],
+  ])('uploadOne(): invalid input rejects with an error', (input, expectedError) => {
+    // The following line is meant to be invalid, so convince the linter and the compiler we definitely want to do it
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    return expect(uploadOne(input)).rejects.toThrowError(expectedError)
+  })
+  test.each([
+    [ {}, 'apiKey is required and must be a string' ],
+    [ { apiKey: 123 }, 'apiKey is required and must be a string' ],
+    [ { apiKey: '123' }, 'baseUrl is required and must be a string' ],
+    [ { apiKey: '123', baseUrl: '*' }, 'directory is required and must be a string' ],
+    [ { apiKey: '123', baseUrl: '*', directory: '.', appVersion: 1 }, 'appVersion must be a string' ],
+    [ { apiKey: '123', baseUrl: '*', directory: '.', somethingDifferent: 'yes' }, 'Unrecognized option(s): somethingDifferent' ],
+    [
+      { apiKey: '123', baseUrl: '*', directory: '.', somethingDifferent: 'yes', somethingElse: 'no' },
+      'Unrecognized option(s): somethingDifferent, somethingElse'
+    ],
+  ])('uploadMultiple(): invalid input rejects with an error', (input, expectedError) => {
+    // The following line is meant to be invalid, so convince the linter and the compiler we definitely want to do it
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    return expect(uploadMultiple(input)).rejects.toThrowError(expectedError)
+  })
+})

--- a/src/uploaders/__test__/NodeUploader.test.ts
+++ b/src/uploaders/__test__/NodeUploader.test.ts
@@ -551,3 +551,40 @@ test('uploadMultiple(): failure (connection error)', async () => {
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('An unexpected error occurred'), expect.any(Error), expect.any(Error))
   }
 })
+
+describe('input validation errors (when using as a JS library', () => {
+  test.each([
+    [ {}, 'apiKey is required and must be a string' ],
+    [ { apiKey: 123 }, 'apiKey is required and must be a string' ],
+    [ { apiKey: '123' }, 'sourceMap is required and must be a string' ],
+    [ { apiKey: '123', sourceMap: 'm.map', appVersion: 1 }, 'appVersion must be a string' ],
+    [ { apiKey: '123', sourceMap: 'm.map', logger: null }, 'logger must be an object' ],
+    [ { apiKey: '123', sourceMap: 'm.map', overwrite: 'yes' }, 'overwrite must be true or false' ],
+    [ { apiKey: '123', sourceMap: 'm.map', somethingDifferent: 'yes' }, 'Unrecognized option(s): somethingDifferent' ],
+    [
+      { apiKey: '123', sourceMap: 'm.map', somethingDifferent: 'yes', somethingElse: 'no' },
+      'Unrecognized option(s): somethingDifferent, somethingElse'
+    ],
+  ])('uploadOne(): invalid input rejects with an error', (input, expectedError) => {
+    // The following line is meant to be invalid, so convince the linter and the compiler we definitely want to do it
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    return expect(uploadOne(input)).rejects.toThrowError(expectedError)
+  })
+  test.each([
+    [ {}, 'apiKey is required and must be a string' ],
+    [ { apiKey: 123 }, 'apiKey is required and must be a string' ],
+    [ { apiKey: '123' }, 'directory is required and must be a string' ],
+    [ { apiKey: '123', directory: '.', appVersion: 1 }, 'appVersion must be a string' ],
+    [ { apiKey: '123', directory: '.', somethingDifferent: 'yes' }, 'Unrecognized option(s): somethingDifferent' ],
+    [
+      { apiKey: '123', directory: '.', somethingDifferent: 'yes', somethingElse: 'no' },
+      'Unrecognized option(s): somethingDifferent, somethingElse'
+    ],
+  ])('uploadMultiple(): invalid input rejects with an error', (input, expectedError) => {
+    // The following line is meant to be invalid, so convince the linter and the compiler we definitely want to do it
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    return expect(uploadMultiple(input)).rejects.toThrowError(expectedError)
+  })
+})

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -1036,3 +1036,40 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (timeout)', async ()
     )
   }
 })
+
+describe('input validation errors (when using as a JS library', () => {
+  test.each([
+    [ {}, 'apiKey is required and must be a string' ],
+    [ { apiKey: 123 }, 'apiKey is required and must be a string' ],
+    [ { apiKey: '123' }, 'sourceMap is required and must be a string' ],
+    [ { apiKey: '123', sourceMap: 'm.map', platform: 'ios', appVersion: 1 }, 'appVersion must be a string' ],
+    [ { apiKey: '123', sourceMap: 'm.map', platform: 'ios', logger: null }, 'logger must be an object' ],
+    [ { apiKey: '123', sourceMap: 'm.map', platform: 'ios', overwrite: 'yes' }, 'overwrite must be true or false' ],
+    [ { apiKey: '123', sourceMap: 'm.map', platform: 'ios', somethingDifferent: 'yes' }, 'Unrecognized option(s): somethingDifferent' ],
+    [
+      { apiKey: '123', sourceMap: 'm.map', platform: 'ios', somethingDifferent: 'yes', somethingElse: 'no' },
+      'Unrecognized option(s): somethingDifferent, somethingElse'
+    ],
+  ])('uploadOne(): invalid input rejects with an error', (input, expectedError) => {
+    // The following line is meant to be invalid, so convince the linter and the compiler we definitely want to do it
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    return expect(uploadOne(input)).rejects.toThrowError(expectedError)
+  })
+  test.each([
+    [ {}, 'apiKey is required and must be a string' ],
+    [ { apiKey: 123 }, 'apiKey is required and must be a string' ],
+    [ { apiKey: '123', }, 'platform is required and must be a string' ],
+    [ { apiKey: '123', platform: 'ios', appVersion: 1 }, 'appVersion must be a string' ],
+    [ { apiKey: '123', platform: 'ios', somethingDifferent: 'yes' }, 'Unrecognized option(s): somethingDifferent' ],
+    [
+      { apiKey: '123', platform: 'ios', somethingDifferent: 'yes', somethingElse: 'no' },
+      'Unrecognized option(s): somethingDifferent, somethingElse'
+    ],
+  ])('fetchAndUploadOne(): invalid input rejects with an error', (input, expectedError) => {
+    // The following line is meant to be invalid, so convince the linter and the compiler we definitely want to do it
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    return expect(fetchAndUploadOne(input)).rejects.toThrowError(expectedError)
+  })
+})

--- a/src/uploaders/lib/InputValidators.ts
+++ b/src/uploaders/lib/InputValidators.ts
@@ -1,0 +1,40 @@
+export function validateRequiredStrings (opts: Record<string, unknown>, keys: string[]): void {
+  // required strings
+  for (const requiredString of keys) {
+    if (typeof opts[requiredString] !== 'string' || (opts[requiredString] as string).length === 0) {
+      throw new Error(`${requiredString} is required and must be a string`)
+    }
+  }
+}
+
+export function validateOptionalStrings (opts: Record<string, unknown>, keys: string[]): void {
+  for (const optionalString of keys) {
+    if (typeof opts[optionalString] !== 'undefined') {
+      if (typeof opts[optionalString] !== 'string' || (opts[optionalString] as string).length === 0) {
+        throw new Error(`${optionalString} must be a string`)
+      }
+    }
+  }
+}
+
+export function validateBooleans (opts: Record<string, unknown>, keys: string[]): void {
+  for (const bool of keys) {
+    if (typeof opts[bool] !== 'boolean') {
+      throw new Error(`${bool} must be true or false`)
+    }
+  }
+}
+
+export function validateObjects (opts: Record<string, unknown>, keys: string[]): void {
+  for (const obj of keys) {
+    if (typeof opts[obj] !== 'object' || !opts[obj]) {
+      throw new Error(`${obj} must be an object`)
+    }
+  }
+}
+
+export function validateNoUnknownArgs (unknownArgs: Record<string, unknown>): void {
+  if (Object.keys(unknownArgs).length > 0) {
+    throw new Error(`Unrecognized option(s): ${Object.keys(unknownArgs).join(', ')}`)
+  }
+}


### PR DESCRIPTION
## Goal

When used via TypeScript, as we do in our commands, the uploader libraries have type information that prevent certain kinds of input. However, when used via JS – as is one of the use cases of this package – no such safety is in place. The goal is to add input checking at runtime to ensure early and helpful feedback to the user when invalid input is provided.

## Design

I've implemented a set of reusable input checking functions. Each uploader has slightly different parameters that it supports so the exact validation method is composed of multiple calls to the input checkers specifying the kind of input allowed.

It also checks for unknown options, since this can (and has been) as source of confusion – for instance, passing `bundleUrl` into the Node uploader.

## Changeset

- New `lib/InputValidators.ts` file
- Updated all of the node/browser/reactnative `upload*()` methods to first validate the provided input. If invalid input is detected, these functions will reject a promise with the validation error.

## Testing

- Added test cases for all functions where the input validation was added.