### PR TITLE
Fix source maps uploaded from Windows

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -4,15 +4,15 @@ on: [ push, pull_request ]
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         node-version: [10.x, 12.x, 14.x]
-    steps:
+        os: [ubuntu-20.04, windows-2019]
 
+    steps:
     - uses: actions/checkout@v2
 
     - name: Use Node.js ${{ matrix.node-version }}

--- a/src/transformers/StripProjectRoot.ts
+++ b/src/transformers/StripProjectRoot.ts
@@ -27,6 +27,6 @@ function strip (sourceMapPath: string, map: UnsafeSourceMap, projectRoot: string
       path.dirname(sourceMapPath),
       s.replace(/webpack:\/\/\/\.\//, `${projectRoot}/`)
     )
-    return absoluteSourcePath.replace(projectRoot, '').replace(/^\//, '')
+    return absoluteSourcePath.replace(projectRoot, '').replace(/^(\/|\\)/, '')
   })
 }

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -102,7 +102,7 @@ export async function uploadOne ({
       type: PayloadType.Node,
       apiKey,
       appVersion,
-      minifiedUrl: bundle,
+      minifiedUrl: bundle.replace(/\\/g, '/'),
       minifiedFile: new File(fullBundlePath, bundleContent),
       sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
       overwrite: overwrite
@@ -223,7 +223,7 @@ export async function uploadMultiple ({
         type: PayloadType.Node,
         apiKey,
         appVersion,
-        minifiedUrl: path.relative(projectRoot, path.resolve(absoluteSearchPath, bundlePath)),
+        minifiedUrl: path.relative(projectRoot, path.resolve(absoluteSearchPath, bundlePath)).replace(/\\/g, '/'),
         minifiedFile: (bundleContent && fullBundlePath) ? new File(fullBundlePath, bundleContent) : undefined,
         sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
         overwrite: overwrite


### PR DESCRIPTION
## Goal

Uploading source maps from Windows has a couple of issues currently:

1. The project root isn't stripped from mapped file paths
2. Uploaded source maps will only match file paths when the code is deployed on Windows because it uses platform specific directory separators