### PR TITLE
feat: Fully support codeBundleId on node and browser uploads

### DIFF
--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -139,6 +139,34 @@ Feature: Browser source map upload multiple
     And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
+  Scenario: codeBundleId support
+    When I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --code-bundle-id r0012
+        --directory dist
+        --base-url "http://myapp.url/static/js/"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 3 requests
+    Then the last run docker command exited successfully
+    And the Content-Type header is valid multipart form-data for all requests
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "codeBundleId" equals "r0012" for all requests
+    And the payload field "overwrite" is null for all requests
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest request
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
+    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest request
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
+    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+
   Scenario: Overwrite enabled
     When I run the service "multiple-source-map-webpack" with the command
       """

--- a/features/browser-upload-one.feature
+++ b/features/browser-upload-one.feature
@@ -83,6 +83,27 @@ Feature: Browser source map upload one
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
+  Scenario: codeBundleId support
+    When I run the service "single-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --code-bundle-id r0125
+        --source-map dist/main.js.map
+        --bundle dist/main.js
+        --bundle-url "http://myapp.url/static/js/main.js"
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 1 request
+    Then the payload field "apiKey" equals "123"
+    And the payload field "codeBundleId" equals "r0125"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    And the last run docker command exited successfully
+
   Scenario: Overwrite enabled
     When I run the service "single-source-map-webpack" with the command
       """

--- a/features/node-upload-multiple.feature
+++ b/features/node-upload-multiple.feature
@@ -134,6 +134,33 @@ Feature: Node source map upload multiple
     And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
     And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
+  Scenario: codeBundleId support
+    When I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-node
+        --api-key 123
+        --code-bundle-id r0124
+        --directory dist
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 3 requests
+    Then the last run docker command exited successfully
+    And the Content-Type header is valid multipart form-data for all requests
+    And the payload field "apiKey" equals "123" for all requests
+    And the payload field "codeBundleId" equals "r0124" for all requests
+    And the payload field "overwrite" is null for all requests
+    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest request
+    And the payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
+    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest request
+    And the payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
+    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+
   Scenario: Overwrite enabled
     When I run the service "multiple-source-map-webpack" with the command
       """

--- a/features/node-upload-one.feature
+++ b/features/node-upload-one.feature
@@ -79,6 +79,26 @@ Feature: Node source map upload one
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
+  Scenario: codeBundleId support
+    When I run the service "single-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-node
+        --api-key 123
+        --code-bundle-id r0126
+        --source-map dist/main.js.map
+        --bundle dist/main.js
+        --endpoint http://maze-runner:9339
+      """
+    And I wait to receive 1 request
+    Then the payload field "apiKey" equals "123"
+    And the payload field "codeBundleId" equals "r0126"
+    And the payload field "overwrite" is null
+    And the payload field "minifiedUrl" equals "dist/main.js"
+    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the Content-Type header is valid multipart form-data
+    And the last run docker command exited successfully
+
   Scenario: Overwrite enabled
     When I run the service "single-source-map-webpack" with the command
       """

--- a/src/commands/CommandDefinitions.ts
+++ b/src/commands/CommandDefinitions.ts
@@ -4,4 +4,5 @@ export const commonCommandDefs = [
   { name: 'project-root', type: String, description: 'the top level directory of your project (defaults to the current directory)' },
   { name: 'endpoint', type: String, description: 'customize the endpoint for Bugsnag On-Premise' },
   { name: 'quiet', type: Boolean, description: 'less verbose logging' },
+  { name: 'code-bundle-id', type: String }
 ]

--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -48,6 +48,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
         appVersion: browserOpts.appVersion,
         endpoint: browserOpts.endpoint,
         detectAppVersion: browserOpts.detectAppVersion,
+        codeBundleId: browserOpts.codeBundleId,
         logger
       })
     } else {
@@ -61,6 +62,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
         appVersion: browserOpts.appVersion,
         endpoint: browserOpts.endpoint,
         detectAppVersion: browserOpts.detectAppVersion,
+        codeBundleId: browserOpts.codeBundleId,
         logger
       })
     }
@@ -149,6 +151,11 @@ function validateBrowserOpts (opts: Record<string, unknown>): void {
 
   if (opts['appVersion'] && opts['detectAppVersion']) {
     throw new Error('--app-version and --detect-app-version cannot both be given')
+  }
+
+  if (opts.codeBundleId) {
+    if (opts.appVersion) throw new Error('--app-version and --code-bundle-id cannot both be given')
+    if (opts.detectAppVersion) throw new Error('--detect-app-version and --code-bundle-id cannot both be given')
   }
 
   const anySingleSet = opts['sourceMap'] || opts['bundleUrl'] || opts['bundle']

--- a/src/commands/UploadNodeCommand.ts
+++ b/src/commands/UploadNodeCommand.ts
@@ -39,6 +39,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
         appVersion: nodeOpts.appVersion,
         endpoint: nodeOpts.endpoint,
         detectAppVersion: nodeOpts.detectAppVersion,
+        codeBundleId: nodeOpts.codeBundleId,
         logger
       })
     } else {
@@ -51,6 +52,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
         appVersion: nodeOpts.appVersion,
         endpoint: nodeOpts.endpoint,
         detectAppVersion: nodeOpts.detectAppVersion,
+        codeBundleId: nodeOpts.codeBundleId,
         logger
       })
     }
@@ -127,6 +129,11 @@ function validatenodeOpts (opts: Record<string, unknown>): void {
 
   if (opts['appVersion'] && opts['detectAppVersion']) {
     throw new Error('--app-version and --detect-app-version cannot both be given')
+  }
+
+  if (opts.codeBundleId) {
+    if (opts.appVersion) throw new Error('--app-version and --code-bundle-id cannot both be given')
+    if (opts.detectAppVersion) throw new Error('--detect-app-version and --code-bundle-id cannot both be given')
   }
 
   const anySingleSet = opts['sourceMap'] || opts['bundle']

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -115,10 +115,6 @@ const reactNativeCommonDefs = [
     type: String,
   },
   {
-    name: 'code-bundle-id',
-    type: String,
-  },
-  {
     name: 'app-version-code',
     type: String,
   },

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -137,6 +137,7 @@ interface UploadMultipleOpts {
   baseUrl: string
   directory: string
   appVersion?: string
+  codeBundleId?: string,
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
@@ -148,7 +149,7 @@ interface UploadMultipleOpts {
 
 function validateMultipleOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
   validateRequiredStrings(opts, [ 'apiKey', 'baseUrl', 'directory', 'projectRoot', 'endpoint' ])
-  validateOptionalStrings(opts, [ 'appVersion' ])
+  validateOptionalStrings(opts, [ 'appVersion', 'codeBundleId' ])
   validateBooleans(opts, [ 'overwrite', 'detectAppVersion' ])
   validateObjects(opts, [ 'requestOpts', 'logger' ])
   validateNoUnknownArgs(unknownArgs)
@@ -159,6 +160,7 @@ export async function uploadMultiple ({
   baseUrl,
   directory,
   appVersion,
+  codeBundleId,
   overwrite = false,
   detectAppVersion = false,
   projectRoot = process.cwd(),
@@ -172,6 +174,7 @@ export async function uploadMultiple ({
     baseUrl,
     directory,
     appVersion,
+    codeBundleId,
     overwrite,
     projectRoot,
     endpoint,
@@ -241,6 +244,7 @@ export async function uploadMultiple ({
         type: PayloadType.Browser,
         apiKey,
         appVersion,
+        codeBundleId,
         minifiedUrl: `${baseUrl.replace(/\/$/, '')}/${bundlePath}`,
         minifiedFile: (bundleContent && fullBundlePath) ? new File(fullBundlePath, bundleContent) : undefined,
         sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -27,6 +27,7 @@ interface UploadSingleOpts {
   sourceMap: string
   bundle: string
   appVersion?: string
+  codeBundleId?: string
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
@@ -37,7 +38,7 @@ interface UploadSingleOpts {
 
 function validateOneOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
   validateRequiredStrings(opts, [ 'apiKey', 'sourceMap', 'projectRoot', 'endpoint' ])
-  validateOptionalStrings(opts, [ 'bundle', 'appVersion' ])
+  validateOptionalStrings(opts, [ 'bundle', 'appVersion', 'codeBundleId' ])
   validateBooleans(opts, [ 'overwrite', 'detectAppVersion' ])
   validateObjects(opts, [ 'requestOpts', 'logger' ])
   validateNoUnknownArgs(unknownArgs)
@@ -48,6 +49,7 @@ export async function uploadOne ({
   bundle,
   sourceMap,
   appVersion,
+  codeBundleId,
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -61,6 +63,7 @@ export async function uploadOne ({
     bundle,
     sourceMap,
     appVersion,
+    codeBundleId,
     overwrite,
     projectRoot,
     endpoint,
@@ -102,6 +105,7 @@ export async function uploadOne ({
       type: PayloadType.Node,
       apiKey,
       appVersion,
+      codeBundleId,
       minifiedUrl: bundle.replace(/\\/g, '/'),
       minifiedFile: new File(fullBundlePath, bundleContent),
       sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
@@ -122,6 +126,7 @@ interface UploadMultipleOpts {
   apiKey: string
   directory: string
   appVersion?: string
+  codeBundleId?: string
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
@@ -132,7 +137,7 @@ interface UploadMultipleOpts {
 
 function validateMultipleOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
   validateRequiredStrings(opts, [ 'apiKey', 'directory', 'projectRoot', 'endpoint' ])
-  validateOptionalStrings(opts, [ 'appVersion' ])
+  validateOptionalStrings(opts, [ 'appVersion', 'codeBundleId' ])
   validateBooleans(opts, [ 'overwrite', 'detectAppVersion' ])
   validateObjects(opts, [ 'requestOpts', 'logger' ])
   validateNoUnknownArgs(unknownArgs)
@@ -142,6 +147,7 @@ export async function uploadMultiple ({
   apiKey,
   directory,
   appVersion,
+  codeBundleId,
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -154,6 +160,7 @@ export async function uploadMultiple ({
     apiKey,
     directory,
     appVersion,
+    codeBundleId,
     overwrite,
     projectRoot,
     endpoint,
@@ -223,6 +230,7 @@ export async function uploadMultiple ({
         type: PayloadType.Node,
         apiKey,
         appVersion,
+        codeBundleId,
         minifiedUrl: path.relative(projectRoot, path.resolve(absoluteSearchPath, bundlePath)).replace(/\\/g, '/'),
         minifiedFile: (bundleContent && fullBundlePath) ? new File(fullBundlePath, bundleContent) : undefined,
         sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -67,6 +67,25 @@ test('uploadOne(): dispatches a request with the correct params (no bundle)', as
   )
 })
 
+test('uploadOne(): codeBundleId', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadOne({
+    apiKey: '123',
+    bundleUrl: 'http://mybundle.jim',
+    sourceMap: 'bundle.js.map',
+    appVersion: '1.2.3',
+    projectRoot: path.join(__dirname, 'fixtures/a'),
+    codeBundleId: 'r0001'
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/sourcemap',
+    expect.objectContaining({ codeBundleId: 'r0001' }),
+    expect.objectContaining({})
+  )
+})
+
 test('uploadOne(): failure (unexpected network error)', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
   const err = new NetworkError('misc upload error')
@@ -547,6 +566,41 @@ test('uploadMultiple(): success passing appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/runtime-main.ad66c902.js',
       appVersion: '4.5.6'
     }),
+    expect.objectContaining({})
+  )
+})
+
+test('uploadMultiple(): success with codeBundleId', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadMultiple({
+    apiKey: '123',
+    baseUrl: 'http://mybundle.jim/',
+    directory: 'build',
+    projectRoot: path.join(__dirname, 'fixtures/h'),
+    appVersion: '4.5.6',
+    logger: mockLogger,
+    codeBundleId: 'r00012'
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(4)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/sourcemap',
+    expect.objectContaining({ codeBundleId: 'r00012' }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/sourcemap',
+    expect.objectContaining({ codeBundleId: 'r00012'}),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/sourcemap',
+    expect.objectContaining({ codeBundleId: 'r00012' }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/sourcemap',
+    expect.objectContaining({ codeBundleId: 'r00012' }),
     expect.objectContaining({})
   )
 })

--- a/src/uploaders/__test__/NodeUploader.test.ts
+++ b/src/uploaders/__test__/NodeUploader.test.ts
@@ -230,6 +230,31 @@ test('uploadOne(): custom endpoint (invalid URL)', async () => {
   }
 })
 
+test('uploadOne(): codeBundleId', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadOne({
+    apiKey: '123',
+    sourceMap: 'bundle.js.map',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/a'),
+    logger: mockLogger,
+    codeBundleId: 'r0001'
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/sourcemap',
+    expect.objectContaining({
+      apiKey: '123',
+      minifiedFile: expect.any(Object),
+      overwrite: false,
+      sourceMap: expect.any(Object),
+      codeBundleId: 'r0001'
+    }),
+    expect.objectContaining({})
+  )
+})
+
 test('uploadMultiple(): success', async () => {
   const mockedRequest  = request as jest.MockedFunction<typeof request>
   mockedRequest.mockResolvedValue()
@@ -378,6 +403,39 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'build/static/js/runtime-main.ad66c902.js',
       appVersion: '1.2.3'
     }),
+    expect.objectContaining({})
+  )
+})
+
+test('uploadMultiple(): success with codeBundleId', async () => {
+  const mockedRequest  = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+  await uploadMultiple({
+    apiKey: '123',
+    directory: 'build/static/js',
+    projectRoot: path.join(__dirname, 'fixtures/c'),
+    logger: mockLogger,
+    codeBundleId: 'r00012'
+  })
+  expect(mockedRequest).toHaveBeenCalledTimes(4)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/sourcemap',
+    expect.objectContaining({ codeBundleId: 'r00012' }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/sourcemap',
+    expect.objectContaining({ codeBundleId: 'r00012'}),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/sourcemap',
+    expect.objectContaining({ codeBundleId: 'r00012' }),
+    expect.objectContaining({})
+  )
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.bugsnag.com/sourcemap',
+    expect.objectContaining({ codeBundleId: 'r00012' }),
     expect.objectContaining({})
   )
 })


### PR DESCRIPTION
`codeBundleId` is necessary for Electron. Rather than introducing a new command, we simply support it for node and browser uploads. It was already partially supported by `browser.uploadOne()` – but only via the JS interface.