### PR TITLE
Add missing URL import

### DIFF
--- a/src/uploaders/lib/EndpointUrl.ts
+++ b/src/uploaders/lib/EndpointUrl.ts
@@ -1,3 +1,5 @@
+import { URL } from 'url'
+
 export const DEFAULT_UPLOAD_ORIGIN = 'https://upload.bugsnag.com'
 
 export function buildEndpointUrl (origin: string, path: string): string {


### PR DESCRIPTION
This should fix the following error seen:

(node:17) UnhandledPromiseRejectionWarning: ReferenceError: URL is not defined
    at Object.buildEndpointUrl (/app/node_modules/@bugsnag/source-maps/dist/uploaders/lib/EndpointUrl.js:6:17)
    at Object.<anonymous> (/app/node_modules/@bugsnag/source-maps/dist/uploaders/BrowserUploader.js:90:33)
    at Generator.next (<anonymous>)
    at /app/node_modules/@bugsnag/source-maps/dist/uploaders/BrowserUploader.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/app/node_modules/@bugsnag/source-maps/dist/uploaders/BrowserUploader.js:4:12)
    at Object.uploadMultiple (/app/node_modules/@bugsnag/source-maps/dist/uploaders/BrowserUploader.js:86:12)
    at Object.<anonymous> (/app/script/bugsnag-upload.js:18:9)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)

## Goal

<!-- Why is this change necessary? -->

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->