### PR TITLE
feat: Support --overwrite and --no-overwrite everywhere

### DIFF
--- a/src/commands/CommandDefinitions.ts
+++ b/src/commands/CommandDefinitions.ts
@@ -1,6 +1,7 @@
 export const commonCommandDefs = [
   { name: 'api-key', type: String, description: 'your project\'s API key {bold required}' },
-  { name: 'overwrite', type: Boolean, description: 'whether to replace exiting source maps uploaded with the same version' },
+  { name: 'overwrite', type: Boolean, description: 'replace existing source maps uploaded with the same version' },
+  { name: 'no-overwrite', type: Boolean, description: 'prevent replacement of existing source maps uploaded with the same version' },
   { name: 'project-root', type: String, description: 'the top level directory of your project (defaults to the current directory)' },
   { name: 'endpoint', type: String, description: 'customize the endpoint for Bugsnag On-Premise' },
   { name: 'quiet', type: Boolean, description: 'less verbose logging' },

--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -36,6 +36,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
     return browserUsage()
   }
   try {
+    const overwrite = browserOpts.overwrite && !browserOpts['noOverwrite']
     if (browserOpts.sourceMap) {
       // single mode
       await browser.uploadOne({
@@ -44,7 +45,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
         bundleUrl: browserOpts.bundleUrl,
         bundle: browserOpts.bundle,
         projectRoot: browserOpts.projectRoot,
-        overwrite: browserOpts.overwrite,
+        overwrite,
         appVersion: browserOpts.appVersion,
         endpoint: browserOpts.endpoint,
         detectAppVersion: browserOpts.detectAppVersion,
@@ -58,7 +59,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
         baseUrl: browserOpts.baseUrl,
         directory: browserOpts.directory,
         projectRoot: browserOpts.projectRoot,
-        overwrite: browserOpts.overwrite,
+        overwrite,
         appVersion: browserOpts.appVersion,
         endpoint: browserOpts.endpoint,
         detectAppVersion: browserOpts.detectAppVersion,
@@ -151,6 +152,10 @@ function validateBrowserOpts (opts: Record<string, unknown>): void {
 
   if (opts['appVersion'] && opts['detectAppVersion']) {
     throw new Error('--app-version and --detect-app-version cannot both be given')
+  }
+
+  if (opts['overwrite'] && opts['noOverwrite']) {
+    throw new Error('--overwrite and --no-overwrite cannot both be given')
   }
 
   if (opts.codeBundleId) {

--- a/src/commands/UploadNodeCommand.ts
+++ b/src/commands/UploadNodeCommand.ts
@@ -28,6 +28,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
     return nodeUsage()
   }
   try {
+    const overwrite = nodeOpts.overwrite && !nodeOpts['noOverwrite']
     if (nodeOpts.sourceMap) {
       // single mode
       await node.uploadOne({
@@ -35,7 +36,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
         sourceMap: nodeOpts.sourceMap,
         bundle: nodeOpts.bundle,
         projectRoot: nodeOpts.projectRoot,
-        overwrite: nodeOpts.overwrite,
+        overwrite,
         appVersion: nodeOpts.appVersion,
         endpoint: nodeOpts.endpoint,
         detectAppVersion: nodeOpts.detectAppVersion,
@@ -48,7 +49,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
         apiKey: nodeOpts.apiKey,
         directory: nodeOpts.directory,
         projectRoot: nodeOpts.projectRoot,
-        overwrite: nodeOpts.overwrite,
+        overwrite,
         appVersion: nodeOpts.appVersion,
         endpoint: nodeOpts.endpoint,
         detectAppVersion: nodeOpts.detectAppVersion,
@@ -129,6 +130,10 @@ function validatenodeOpts (opts: Record<string, unknown>): void {
 
   if (opts['appVersion'] && opts['detectAppVersion']) {
     throw new Error('--app-version and --detect-app-version cannot both be given')
+  }
+
+  if (opts['overwrite'] && opts['noOverwrite']) {
+    throw new Error('--overwrite and --no-overwrite cannot both be given')
   }
 
   if (opts.codeBundleId) {

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -11,7 +11,7 @@ export default async function uploadReactNative (argv: string[], opts: Record<st
   }
 
   const defs: OptionDefinition[] = [
-    ...commonCommandDefs.filter(def => def.name !== 'overwrite'),
+    ...commonCommandDefs,
     ...reactNativeCommonDefs,
     ...reactNativeProvideOpts,
     ...reactNativeFetchOpts,
@@ -40,11 +40,12 @@ export default async function uploadReactNative (argv: string[], opts: Record<st
   }
 
   try {
+    const overwrite = reactNativeOpts.overwrite && !reactNativeOpts['noOverwrite']
     if (reactNativeOpts.fetch) {
       await fetchAndUploadOne({
         apiKey: reactNativeOpts.apiKey,
         projectRoot: reactNativeOpts.projectRoot,
-        overwrite: !reactNativeOpts.noOverwrite,
+        overwrite,
         appVersion: reactNativeOpts.appVersion,
         codeBundleId: reactNativeOpts.codeBundleId,
         appBundleVersion: reactNativeOpts.appBundleVersion,
@@ -62,7 +63,7 @@ export default async function uploadReactNative (argv: string[], opts: Record<st
         sourceMap: reactNativeOpts.sourceMap,
         bundle: reactNativeOpts.bundle,
         projectRoot: reactNativeOpts.projectRoot,
-        overwrite: !reactNativeOpts.noOverwrite,
+        overwrite,
         appVersion: reactNativeOpts.appVersion,
         codeBundleId: reactNativeOpts.codeBundleId,
         appBundleVersion: reactNativeOpts.appBundleVersion,
@@ -126,11 +127,6 @@ const reactNativeCommonDefs = [
     name: 'dev',
     type: Boolean,
     description: 'indicates this is a debug build',
-  },
-  {
-    name: 'no-overwrite',
-    type: Boolean,
-    description: 'prevent exiting source maps uploaded with the same version from being replaced'
   }
 ]
 
@@ -172,6 +168,10 @@ const reactNativeFetchOpts = [
 function validateReactNativeOpts (opts: Record<string, unknown>): void {
   if (!opts.apiKey || typeof opts.apiKey !== 'string') {
     throw new Error('--api-key is a required parameter')
+  }
+
+  if (opts['overwrite'] && opts['noOverwrite']) {
+    throw new Error('--overwrite and --no-overwrite cannot both be given')
   }
 
   validatePlatform(opts)


### PR DESCRIPTION
## Goal

For tools using this module under the hood, remove the need for logic to determine whether `--overwrite` or `--no-overwrite` are required and simply allow both everywhere (even if they are the default behaviour).

Previously if `--overwrite` was supplied to the `upload-react-native` command, it would error because the default was to overwrite, and it only supported the `--no-overwrite` option.
