### PR TITLE
Add `--idle-timeout` flag

### DIFF
--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -343,3 +343,26 @@ Feature: Browser source map upload multiple
     And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
     And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
+
+  Scenario: A request can set a timeout using the --idle-timeout flag
+    When I set the response delay to 5000 milliseconds
+    And I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --directory dist
+        --base-url "http://myapp.url/static/js/"
+        --endpoint http://maze-runner:9339
+        --idle-timeout 0.0008 # approx 50ms in minutes
+      """
+    Then the last run docker command did not exit successfully
+    And the last run docker command output "The request timed out."
+    When I wait to receive 5 sourcemaps
+    Then the Content-Type header is valid multipart form-data for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack" for all requests

--- a/features/node-upload-multiple.feature
+++ b/features/node-upload-multiple.feature
@@ -330,3 +330,25 @@ Feature: Node source map upload multiple
     And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
     And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
+
+  Scenario: A request can set a timeout using the --idle-timeout flag
+    When I set the response delay to 5000 milliseconds
+    And I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-node
+        --api-key 123
+        --app-version 2.0.0
+        --directory dist
+        --endpoint http://maze-runner:9339
+        --idle-timeout 0.0008 # approx 50ms in minutes
+      """
+    Then the last run docker command did not exit successfully
+    And the last run docker command output "The request timed out."
+    When I wait to receive 5 sourcemaps
+    And the Content-Type header is valid multipart form-data for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack" for all requests

--- a/features/node-upload-one.feature
+++ b/features/node-upload-one.feature
@@ -255,3 +255,26 @@ Feature: Node source map upload one
     And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
     And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
+
+  Scenario: A request can set a timeout using the --idle-timeout flag
+    When I set the response delay to 5000 milliseconds
+    And I run the service "single-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-node
+        --api-key 123
+        --app-version 2.0.0
+        --source-map dist/main.js.map
+        --bundle dist/main.js
+        --endpoint http://maze-runner:9339
+        --idle-timeout 0.0008 # approx 50ms in minutes
+      """
+    Then the last run docker command did not exit successfully
+    And the last run docker command output "The request timed out."
+    When I wait to receive 5 sourcemaps
+    And the Content-Type header is valid multipart form-data for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack" for all requests

--- a/features/react-native-fetch.feature
+++ b/features/react-native-fetch.feature
@@ -190,3 +190,24 @@ Feature: React native source map fetch mode
     And the sourcemap payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
     And the sourcemap payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
+
+  Scenario: A request can set a timeout using the --idle-timeout flag
+    When I start the service "react-native-0-60-bundler"
+    And I wait for 2 seconds
+    And I set the response delay to 5000 milliseconds
+    And I run the service "react-native-0-60-fetch" with the command
+    """
+    bugsnag-source-maps upload-react-native
+      --api-key 123
+      --app-version 2.0.0
+      --endpoint http://maze-runner:9339
+      --fetch
+      --bundler-url http://react-native-0-60-bundler:9449
+      --platform ios
+      --idle-timeout 0.0008 # approx 50ms in minutes
+    """
+    Then the last run docker command did not exit successfully
+    And the last run docker command output "The request to http://react-native-0-60-bundler:9449 timed out."
+    # this is fetch mode so no sourcemaps should be uploaded because the request
+    # to the RN bundle server should timeout due to the idle-timeout
+    And I should receive no requests

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -43,7 +43,7 @@ interface RequestOptions {
 
 const MAX_ATTEMPTS = 5
 const RETRY_INTERVAL_MS = parseInt(process.env.BUGSNAG_RETRY_INTERVAL_MS as string) || 1000
-const DEFAULT_TIMEOUT_MS = parseInt(process.env.BUGSNAG_TIMEOUT_MS as string) || 30000
+const DEFAULT_TIMEOUT_MS = parseInt(process.env.BUGSNAG_TIMEOUT_MS as string) || 60000
 
 export default async function request (
   endpoint: string,

--- a/src/commands/CommandDefinitions.ts
+++ b/src/commands/CommandDefinitions.ts
@@ -5,5 +5,6 @@ export const commonCommandDefs = [
   { name: 'project-root', type: String, description: 'the top level directory of your project (defaults to the current directory)' },
   { name: 'endpoint', type: String, description: 'customize the endpoint for Bugsnag On-Premise' },
   { name: 'quiet', type: Boolean, description: 'less verbose logging' },
-  { name: 'code-bundle-id', type: String }
+  { name: 'code-bundle-id', type: String },
+  { name: 'idle-timeout', type: Number, description: 'idle timeout for HTTP requests in minutes' }
 ]

--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -50,6 +50,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
         endpoint: browserOpts.endpoint,
         detectAppVersion: browserOpts.detectAppVersion,
         codeBundleId: browserOpts.codeBundleId,
+        idleTimeout: browserOpts.idleTimeout,
         logger
       })
     } else {
@@ -64,6 +65,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
         endpoint: browserOpts.endpoint,
         detectAppVersion: browserOpts.detectAppVersion,
         codeBundleId: browserOpts.codeBundleId,
+        idleTimeout: browserOpts.idleTimeout,
         logger
       })
     }

--- a/src/commands/UploadNodeCommand.ts
+++ b/src/commands/UploadNodeCommand.ts
@@ -41,6 +41,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
         endpoint: nodeOpts.endpoint,
         detectAppVersion: nodeOpts.detectAppVersion,
         codeBundleId: nodeOpts.codeBundleId,
+        idleTimeout: nodeOpts.idleTimeout,
         logger
       })
     } else {
@@ -54,6 +55,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
         endpoint: nodeOpts.endpoint,
         detectAppVersion: nodeOpts.detectAppVersion,
         codeBundleId: nodeOpts.codeBundleId,
+        idleTimeout: nodeOpts.idleTimeout,
         logger
       })
     }

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -55,6 +55,7 @@ export default async function uploadReactNative (argv: string[], opts: Record<st
         endpoint: reactNativeOpts.endpoint,
         bundlerUrl: reactNativeOpts.bundlerUrl,
         bundlerEntryPoint: reactNativeOpts.bundlerEntryPoint,
+        idleTimeout: reactNativeOpts.idleTimeout,
         logger
       })
     } else {
@@ -71,6 +72,7 @@ export default async function uploadReactNative (argv: string[], opts: Record<st
         platform: reactNativeOpts.platform,
         dev: reactNativeOpts.dev,
         endpoint: reactNativeOpts.endpoint,
+        idleTimeout: reactNativeOpts.idleTimeout,
         logger
       })
     }

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -32,7 +32,8 @@ interface UploadSingleOpts {
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
-  detectAppVersion?: boolean,
+  detectAppVersion?: boolean
+  idleTimeout?: number
   requestOpts?: http.RequestOptions
   logger?: Logger
 }
@@ -52,6 +53,7 @@ export async function uploadOne ({
   sourceMap,
   appVersion,
   codeBundleId,
+  idleTimeout,
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -117,7 +119,7 @@ export async function uploadOne ({
       minifiedFile: (bundleContent && fullBundlePath) ? new File(fullBundlePath, bundleContent) : undefined,
       sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
       overwrite: overwrite
-    }, requestOpts)
+    }, requestOpts, { idleTimeout })
 
     const uploadedFiles = (bundleContent && fullBundlePath) ? `${sourceMap} and ${bundle}` : sourceMap
 
@@ -141,7 +143,8 @@ interface UploadMultipleOpts {
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
-  detectAppVersion?: boolean,
+  detectAppVersion?: boolean
+  idleTimeout?: number
   requestOpts?: http.RequestOptions
   logger?: Logger
 }
@@ -161,6 +164,7 @@ export async function uploadMultiple ({
   directory,
   appVersion,
   codeBundleId,
+  idleTimeout,
   overwrite = false,
   detectAppVersion = false,
   projectRoot = process.cwd(),
@@ -249,7 +253,7 @@ export async function uploadMultiple ({
         minifiedFile: (bundleContent && fullBundlePath) ? new File(fullBundlePath, bundleContent) : undefined,
         sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
         overwrite: overwrite
-      }, requestOpts)
+      }, requestOpts, { idleTimeout })
 
       const uploadedFiles = (bundleContent && fullBundlePath) ? `${sourceMap} and ${bundlePath}` : sourceMap
 

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -34,6 +34,7 @@ interface UploadSingleOpts {
   detectAppVersion?: boolean
   requestOpts?: http.RequestOptions
   logger?: Logger
+  idleTimeout?: number
 }
 
 function validateOneOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
@@ -50,6 +51,7 @@ export async function uploadOne ({
   sourceMap,
   appVersion,
   codeBundleId,
+  idleTimeout,
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -110,7 +112,7 @@ export async function uploadOne ({
       minifiedFile: new File(fullBundlePath, bundleContent),
       sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
       overwrite: overwrite
-    }, requestOpts)
+    }, requestOpts, { idleTimeout })
     logger.success(`Success, uploaded ${sourceMap} and ${bundle} to ${url} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {
@@ -133,6 +135,7 @@ interface UploadMultipleOpts {
   detectAppVersion?: boolean
   requestOpts?: http.RequestOptions
   logger?: Logger
+  idleTimeout?: number
 }
 
 function validateMultipleOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
@@ -148,6 +151,7 @@ export async function uploadMultiple ({
   directory,
   appVersion,
   codeBundleId,
+  idleTimeout,
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -235,7 +239,7 @@ export async function uploadMultiple ({
         minifiedFile: (bundleContent && fullBundlePath) ? new File(fullBundlePath, bundleContent) : undefined,
         sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
         overwrite: overwrite
-      }, requestOpts)
+      }, requestOpts, { idleTimeout })
 
       const uploadedFiles = (bundleContent && fullBundlePath) ? `${sourceMap} and ${bundlePath}` : sourceMap
 

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -35,6 +35,7 @@ interface CommonUploadOpts {
   endpoint?: string
   requestOpts?: http.RequestOptions
   logger?: Logger
+  idleTimeout?: number
 }
 
 interface UploadSingleOpts extends CommonUploadOpts {
@@ -60,6 +61,7 @@ export async function uploadOne ({
   codeBundleId,
   appVersionCode,
   appBundleVersion,
+  idleTimeout,
   overwrite = true,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -114,7 +116,7 @@ export async function uploadOne ({
       dev,
       ...marshalledVersions,
       overwrite
-    }, requestOpts)
+    }, requestOpts, { idleTimeout })
     logger.success(`Success, uploaded ${sourceMap} and ${bundle} to ${url} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {
@@ -147,6 +149,7 @@ export async function fetchAndUploadOne ({
   codeBundleId,
   appVersionCode,
   appBundleVersion,
+  idleTimeout,
   overwrite = true,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -194,7 +197,7 @@ export async function fetchAndUploadOne ({
 
   try {
     logger.debug(`Fetching source map from ${sourceMapUrl}`)
-    sourceMap = await fetch(sourceMapUrl)
+    sourceMap = await fetch(sourceMapUrl, { idleTimeout })
   } catch (e) {
     logger.error(
       formatFetchError(e, bundlerUrl, bundlerEntryPoint), e
@@ -204,7 +207,7 @@ export async function fetchAndUploadOne ({
 
   try {
     logger.debug(`Fetching bundle from ${bundleUrl}`)
-    bundle = await fetch(bundleUrl)
+    bundle = await fetch(bundleUrl, { idleTimeout })
   } catch (e) {
     logger.error(
       formatFetchError(e, bundlerUrl, bundlerEntryPoint), e
@@ -231,7 +234,7 @@ export async function fetchAndUploadOne ({
       dev,
       ...marshalledVersions,
       overwrite
-    }, requestOpts)
+    }, requestOpts, { idleTimeout })
     logger.success(`Success, uploaded ${entryPoint}.js.map to ${url} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -38,7 +38,8 @@ test('uploadOne(): dispatches a request with the correct params', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -63,7 +64,8 @@ test('uploadOne(): dispatches a request with the correct params (no bundle)', as
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -82,7 +84,8 @@ test('uploadOne(): codeBundleId', async () => {
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r0001' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -348,7 +351,8 @@ test('uploadOne(): custom endpoint (origin only)', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -374,7 +378,8 @@ test('uploadOne(): custom endpoint (absolute)', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -426,7 +431,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/2.e5bb21a6.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -444,7 +450,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/3.1b8b4fc7.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -462,7 +469,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/main.286ac573.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -480,7 +488,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/runtime-main.ad66c902.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -512,7 +521,8 @@ test('uploadMultiple(): success passing appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/2.e5bb21a6.chunk.js',
       appVersion: '4.5.6'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -530,7 +540,8 @@ test('uploadMultiple(): success passing appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/3.1b8b4fc7.chunk.js',
       appVersion: '4.5.6'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -548,7 +559,8 @@ test('uploadMultiple(): success passing appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/main.286ac573.chunk.js',
       appVersion: '4.5.6'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -566,7 +578,8 @@ test('uploadMultiple(): success passing appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/runtime-main.ad66c902.js',
       appVersion: '4.5.6'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -586,22 +599,26 @@ test('uploadMultiple(): success with codeBundleId', async () => {
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012'}),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -634,7 +651,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'http://mybundle.jim/static/js/2.e5bb21a6.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -652,7 +670,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'http://mybundle.jim/static/js/3.1b8b4fc7.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -670,7 +689,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'http://mybundle.jim/static/js/main.286ac573.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -688,7 +708,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'http://mybundle.jim/static/js/runtime-main.ad66c902.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 

--- a/src/uploaders/__test__/NodeUploader.test.ts
+++ b/src/uploaders/__test__/NodeUploader.test.ts
@@ -37,7 +37,8 @@ test('uploadOne(): dispatches a request with the correct params', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -62,7 +63,8 @@ test('uploadOne(): dispatches a request with the correct params and detected app
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -183,7 +185,8 @@ test('uploadOne(): custom endpoint (origin only)', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -207,7 +210,8 @@ test('uploadOne(): custom endpoint (absolute)', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -251,7 +255,8 @@ test('uploadOne(): codeBundleId', async () => {
       sourceMap: expect.any(Object),
       codeBundleId: 'r0001'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -282,7 +287,8 @@ test('uploadMultiple(): success', async () => {
       minifiedUrl: 'dist/a.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -300,7 +306,8 @@ test('uploadMultiple(): success', async () => {
       minifiedUrl: 'dist/b.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -318,7 +325,8 @@ test('uploadMultiple(): success', async () => {
       minifiedUrl: 'dist/index.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -349,7 +357,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'build/static/js/2.e5bb21a6.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -367,7 +376,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'build/static/js/3.1b8b4fc7.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -385,7 +395,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'build/static/js/main.286ac573.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -403,7 +414,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'build/static/js/runtime-main.ad66c902.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -421,22 +433,26 @@ test('uploadMultiple(): success with codeBundleId', async () => {
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012'}),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -467,7 +483,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'dist/a.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -485,7 +502,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'dist/b.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -503,7 +521,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'dist/index.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -45,7 +45,8 @@ test('uploadOne(): dispatches a request with the correct params for Android with
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -76,7 +77,8 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -109,7 +111,8 @@ test('uploadOne(): dispatches a request with the correct params for Android with
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -142,7 +145,8 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -174,7 +178,8 @@ test('uploadOne(): dispatches a request with the correct params for Android with
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest.mock.calls[0][1]).toEqual(expect.not.objectContaining({ appVersionCode: '3.2.1' }))
 })
@@ -207,7 +212,8 @@ test('uploadOne(): dispatches a request with the correct params for iOS with cod
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest.mock.calls[0][1]).toEqual(expect.not.objectContaining({ appBundleVersion: '4.5.6' }))
 })
@@ -328,7 +334,8 @@ test('uploadOne(): custom endpoint (absolute)', async () => {
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://bugsnag.my-company.com/source-map-custom',
     expect.objectContaining({ apiKey: '123' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -382,8 +389,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=false')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=false', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=false', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -397,7 +404,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
@@ -429,8 +437,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=ios&dev=false')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=ios&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=ios&dev=false', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=ios&dev=false', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -444,7 +452,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
@@ -475,8 +484,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -490,7 +499,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -517,8 +527,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=ios&dev=true')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=ios&dev=true')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=ios&dev=true', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=ios&dev=true', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -532,7 +542,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -561,8 +572,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -576,7 +587,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
@@ -609,8 +621,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -624,7 +636,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
@@ -657,8 +670,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -672,7 +685,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
@@ -703,7 +717,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (generic Error)'
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
@@ -735,7 +749,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (generic Network
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
@@ -769,7 +783,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (connection refu
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('Unable to connect to http://react-native-bundler:1234. Is the server running?'),
@@ -803,7 +817,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (server error)',
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining("Received an error from the server at http://react-native-bundler:1234. Does the entry point file 'index.js' exist?"),
@@ -837,7 +851,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (timeout)', asyn
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('The request to http://react-native-bundler:1234 timed out.'),
@@ -873,8 +887,8 @@ test('fethchAndUploadOne(): Fetch mode failure to get bundle (generic Error)', a
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(2)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
@@ -910,8 +924,8 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (generic NetworkErro
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(2)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
@@ -949,8 +963,8 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (connection refused)
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(2)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('Unable to connect to http://react-native-bundler:1234. Is the server running?'),
@@ -988,8 +1002,8 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (server error)', asy
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(2)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining("Received an error from the server at http://react-native-bundler:1234. Does the entry point file 'index.js' exist?"),
@@ -1027,8 +1041,8 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (timeout)', async ()
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(2)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('The request to http://react-native-bundler:1234 timed out.'),


### PR DESCRIPTION
## Goal

This PR adds a new `--idle-timeout` flag to all commands which controls the network request idle timeout ([see Node docs](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback))

This is a more user-friendly alternative to the existing environment variable `BUGSNAG_TIMEOUT_MS`. The new flag uses minutes (`--idle-timeout 10` is a 10 minute timeout) which is much more ergonomic than `BUGSNAG_TIMEOUT_MS=60000`

I've also raised the default timeout to 10 minutes as it seemed to be hit somewhat frequently at 5