### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.0 (2021-08-05)
+
+- Add `--idle-timeout` flag to control the HTTP request timeout ([see Node documentation](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback)) [#74](https://github.com/bugsnag/bugsnag-source-maps/pull/74)
+- Increase the default HTTP request timeout to 10 minutes (from 5 minutes) [#74](https://github.com/bugsnag/bugsnag-source-maps/pull/74)
+
 ## 2.2.0 (2021-07-05)
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./:/scan
 
   maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v5-cli
     environment:
       BUILDKITE_JOB_ID:
       VERBOSE:

--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -343,3 +343,26 @@ Feature: Browser source map upload multiple
     And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
     And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
+
+  Scenario: A request can set a timeout using the --idle-timeout flag
+    When I set the response delay to 5000 milliseconds
+    And I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-browser
+        --api-key 123
+        --app-version 2.0.0
+        --directory dist
+        --base-url "http://myapp.url/static/js/"
+        --endpoint http://maze-runner:9339
+        --idle-timeout 0.0008 # approx 50ms in minutes
+      """
+    Then the last run docker command did not exit successfully
+    And the last run docker command output "The request timed out."
+    When I wait to receive 5 sourcemaps
+    Then the Content-Type header is valid multipart form-data for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack" for all requests

--- a/features/browser-upload-multiple.feature
+++ b/features/browser-upload-multiple.feature
@@ -9,23 +9,23 @@ Feature: Browser source map upload multiple
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: Basic success case (webpack) with absolute path --directory
     When I run the service "multiple-source-map-webpack" with the command
@@ -37,23 +37,23 @@ Feature: Browser source map upload multiple
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: Basic success case (babel)
     When I run the service "multiple-source-map-babel-browser" with the command
@@ -65,23 +65,23 @@ Feature: Browser source map upload multiple
         --base-url "http://mybabelapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "http://mybabelapp.url/static/js/index.js"
-    And the payload field "sourceMap" matches the source map "index.json" for "multiple-source-map-babel-browser"
-    And the payload field "minifiedFile" matches the minified file "index.js" for "multiple-source-map-babel-browser"
-    When I discard the oldest request
-    Then the payload field "minifiedUrl" equals "http://mybabelapp.url/static/js/lib/a.js"
-    And the payload field "sourceMap" matches the source map "a.json" for "multiple-source-map-babel-browser"
-    And the payload field "minifiedFile" matches the minified file "a.js" for "multiple-source-map-babel-browser"
-    When I discard the oldest request
-    Then the payload field "minifiedUrl" equals "http://mybabelapp.url/static/js/lib/b.js"
-    And the payload field "sourceMap" matches the source map "b.json" for "multiple-source-map-babel-browser"
-    And the payload field "minifiedFile" matches the minified file "b.js" for "multiple-source-map-babel-browser"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://mybabelapp.url/static/js/index.js"
+    And the sourcemap payload field "sourceMap" matches the source map "index.json" for "multiple-source-map-babel-browser"
+    And the sourcemap payload field "minifiedFile" matches the minified file "index.js" for "multiple-source-map-babel-browser"
+    When I discard the oldest sourcemap
+    Then the sourcemap payload field "minifiedUrl" equals "http://mybabelapp.url/static/js/lib/a.js"
+    And the sourcemap payload field "sourceMap" matches the source map "a.json" for "multiple-source-map-babel-browser"
+    And the sourcemap payload field "minifiedFile" matches the minified file "a.js" for "multiple-source-map-babel-browser"
+    When I discard the oldest sourcemap
+    Then the sourcemap payload field "minifiedUrl" equals "http://mybabelapp.url/static/js/lib/b.js"
+    And the sourcemap payload field "sourceMap" matches the source map "b.json" for "multiple-source-map-babel-browser"
+    And the sourcemap payload field "minifiedFile" matches the minified file "b.js" for "multiple-source-map-babel-browser"
 
   Scenario: Basic success case (typescript)
     When I run the service "multiple-source-map-typescript" with the command
@@ -93,23 +93,23 @@ Feature: Browser source map upload multiple
         --base-url "http://mytypescriptapp.url/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "http://mytypescriptapp.url/js/index.js"
-    And the payload field "sourceMap" matches the source map "index.json" for "multiple-source-map-typescript"
-    And the payload field "minifiedFile" matches the minified file "index.js" for "multiple-source-map-typescript"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://mytypescriptapp.url/js/lib/a.js"
-    And the payload field "sourceMap" matches the source map "a.json" for "multiple-source-map-typescript"
-    And the payload field "minifiedFile" matches the minified file "a.js" for "multiple-source-map-typescript"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://mytypescriptapp.url/js/lib/b.js"
-    And the payload field "sourceMap" matches the source map "b.json" for "multiple-source-map-typescript"
-    And the payload field "minifiedFile" matches the minified file "b.js" for "multiple-source-map-typescript"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://mytypescriptapp.url/js/index.js"
+    And the sourcemap payload field "sourceMap" matches the source map "index.json" for "multiple-source-map-typescript"
+    And the sourcemap payload field "minifiedFile" matches the minified file "index.js" for "multiple-source-map-typescript"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://mytypescriptapp.url/js/lib/a.js"
+    And the sourcemap payload field "sourceMap" matches the source map "a.json" for "multiple-source-map-typescript"
+    And the sourcemap payload field "minifiedFile" matches the minified file "a.js" for "multiple-source-map-typescript"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://mytypescriptapp.url/js/lib/b.js"
+    And the sourcemap payload field "sourceMap" matches the source map "b.json" for "multiple-source-map-typescript"
+    And the sourcemap payload field "minifiedFile" matches the minified file "b.js" for "multiple-source-map-typescript"
 
   Scenario: Detected app version
     When I run the service "multiple-source-map-webpack" with the command
@@ -121,23 +121,23 @@ Feature: Browser source map upload multiple
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "4.5.6" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "4.5.6" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: codeBundleId support
     When I run the service "multiple-source-map-webpack" with the command
@@ -149,23 +149,23 @@ Feature: Browser source map upload multiple
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "codeBundleId" equals "r0012" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "codeBundleId" equals "r0012" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: Overwrite enabled
     When I run the service "multiple-source-map-webpack" with the command
@@ -178,23 +178,23 @@ Feature: Browser source map upload multiple
         --endpoint http://maze-runner:9339
         --overwrite
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" equals "true" for all requests
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" equals "true" for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: A request will be retried on a server failure (500 status code)
     When I set the HTTP status code for the next request to 500
@@ -207,27 +207,27 @@ Feature: Browser source map upload multiple
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 4 requests
+    And I wait to receive 4 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: A request will be retried up to 5 times on a server failure (500 status code)
     When I set the HTTP status code to 500
@@ -240,17 +240,17 @@ Feature: Browser source map upload multiple
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 5 requests
+    And I wait to receive 5 sourcemaps
     Then the last run docker command did not exit successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js" for all requests
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack" for all requests
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack" for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack" for all requests
 
   Scenario: A request will not be retried and further requests will not be made if the API key is invalid (401 status code)
     When I set the HTTP status code for the next request to 401
@@ -263,16 +263,16 @@ Feature: Browser source map upload multiple
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemaps
     Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried and further requests will not be made if the source map is a duplicate (409 status code)
@@ -286,16 +286,16 @@ Feature: Browser source map upload multiple
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemaps
     Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried and further requests will not be made if the bundle or source map is empty (422 status code)
@@ -309,16 +309,16 @@ Feature: Browser source map upload multiple
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemaps
     Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried and further requests will not be made if request is bad (400 status code)
@@ -332,14 +332,14 @@ Feature: Browser source map upload multiple
         --base-url "http://myapp.url/static/js/"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemaps
     Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data

--- a/features/browser-upload-one.feature
+++ b/features/browser-upload-one.feature
@@ -10,13 +10,13 @@ Feature: Browser source map upload one
         --bundle-url "http://myapp.url/static/js/main.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -31,13 +31,13 @@ Feature: Browser source map upload one
         --bundle-url "http://mybabelapp.url/static/js/main.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://mybabelapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-babel-browser"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-babel-browser"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://mybabelapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-babel-browser"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-babel-browser"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -52,13 +52,13 @@ Feature: Browser source map upload one
         --bundle-url "http://myapp.url/static/js/out.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/out.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-typescript"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-typescript"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/out.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-typescript"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-typescript"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -73,13 +73,13 @@ Feature: Browser source map upload one
         --bundle-url "http://myapp.url/static/js/main.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "1.2.3"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "1.2.3"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -94,13 +94,13 @@ Feature: Browser source map upload one
         --bundle-url "http://myapp.url/static/js/main.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "codeBundleId" equals "r0125"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "codeBundleId" equals "r0125"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -116,13 +116,13 @@ Feature: Browser source map upload one
         --endpoint http://maze-runner:9339
         --overwrite
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -138,19 +138,19 @@ Feature: Browser source map upload one
         --bundle-url "http://myapp.url/static/js/main.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 2 requests
+    And I wait to receive 2 sourcemap
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
-    And I discard the oldest request
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
 
   Scenario: A request will be retried up to 5 times on a server failure (500 status code)
     When I set the HTTP status code to 500
@@ -164,17 +164,17 @@ Feature: Browser source map upload one
         --bundle-url "http://myapp.url/static/js/main.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 5 requests
+    And I wait to receive 5 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js" for all requests
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack" for all requests
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack" for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack" for all requests
 
   Scenario: A request will not be retried if the API key is invalid (401 status code)
     When I set the HTTP status code for the next request to 401
@@ -188,16 +188,16 @@ Feature: Browser source map upload one
         --bundle-url "http://myapp.url/static/js/main.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if the source map is a duplicate (409 status code)
@@ -212,16 +212,16 @@ Feature: Browser source map upload one
         --bundle-url "http://myapp.url/static/js/main.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if the bundle or source map is empty (422 status code)
@@ -236,16 +236,16 @@ Feature: Browser source map upload one
         --bundle-url "http://myapp.url/static/js/main.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if request is bad (400 status code)
@@ -260,14 +260,14 @@ Feature: Browser source map upload one
         --bundle-url "http://myapp.url/static/js/main.js"
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "http://myapp.url/static/js/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data

--- a/features/node-upload-multiple.feature
+++ b/features/node-upload-multiple.feature
@@ -330,3 +330,25 @@ Feature: Node source map upload multiple
     And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
     And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
+
+  Scenario: A request can set a timeout using the --idle-timeout flag
+    When I set the response delay to 5000 milliseconds
+    And I run the service "multiple-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-node
+        --api-key 123
+        --app-version 2.0.0
+        --directory dist
+        --endpoint http://maze-runner:9339
+        --idle-timeout 0.0008 # approx 50ms in minutes
+      """
+    Then the last run docker command did not exit successfully
+    And the last run docker command output "The request timed out."
+    When I wait to receive 5 sourcemaps
+    And the Content-Type header is valid multipart form-data for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack" for all requests

--- a/features/node-upload-multiple.feature
+++ b/features/node-upload-multiple.feature
@@ -8,23 +8,23 @@ Feature: Node source map upload multiple
         --directory dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: Basic success case (webpack) with absolute path --directory
     When I run the service "multiple-source-map-webpack" with the command
@@ -35,23 +35,23 @@ Feature: Node source map upload multiple
         --directory /app/dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: Basic success case (babel)
     When I run the service "multiple-source-map-babel-node" with the command
@@ -62,23 +62,23 @@ Feature: Node source map upload multiple
         --directory dist/
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "dist/index.js"
-    And the payload field "sourceMap" matches the source map "index.json" for "multiple-source-map-babel-node"
-    And the payload field "minifiedFile" matches the minified file "index.js" for "multiple-source-map-babel-node"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/lib/a.js"
-    And the payload field "sourceMap" matches the source map "a.json" for "multiple-source-map-babel-node"
-    And the payload field "minifiedFile" matches the minified file "a.js" for "multiple-source-map-babel-node"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/lib/b.js"
-    And the payload field "sourceMap" matches the source map "b.json" for "multiple-source-map-babel-node"
-    And the payload field "minifiedFile" matches the minified file "b.js" for "multiple-source-map-babel-node"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/index.js"
+    And the sourcemap payload field "sourceMap" matches the source map "index.json" for "multiple-source-map-babel-node"
+    And the sourcemap payload field "minifiedFile" matches the minified file "index.js" for "multiple-source-map-babel-node"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/lib/a.js"
+    And the sourcemap payload field "sourceMap" matches the source map "a.json" for "multiple-source-map-babel-node"
+    And the sourcemap payload field "minifiedFile" matches the minified file "a.js" for "multiple-source-map-babel-node"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/lib/b.js"
+    And the sourcemap payload field "sourceMap" matches the source map "b.json" for "multiple-source-map-babel-node"
+    And the sourcemap payload field "minifiedFile" matches the minified file "b.js" for "multiple-source-map-babel-node"
 
   Scenario: Basic success case (typescript)
     When I run the service "multiple-source-map-typescript" with the command
@@ -89,23 +89,23 @@ Feature: Node source map upload multiple
         --directory dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "dist/index.js"
-    And the payload field "sourceMap" matches the source map "index.json" for "multiple-source-map-typescript"
-    And the payload field "minifiedFile" matches the minified file "index.js" for "multiple-source-map-typescript"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/lib/a.js"
-    And the payload field "sourceMap" matches the source map "a.json" for "multiple-source-map-typescript"
-    And the payload field "minifiedFile" matches the minified file "a.js" for "multiple-source-map-typescript"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/lib/b.js"
-    And the payload field "sourceMap" matches the source map "b.json" for "multiple-source-map-typescript"
-    And the payload field "minifiedFile" matches the minified file "b.js" for "multiple-source-map-typescript"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/index.js"
+    And the sourcemap payload field "sourceMap" matches the source map "index.json" for "multiple-source-map-typescript"
+    And the sourcemap payload field "minifiedFile" matches the minified file "index.js" for "multiple-source-map-typescript"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/lib/a.js"
+    And the sourcemap payload field "sourceMap" matches the source map "a.json" for "multiple-source-map-typescript"
+    And the sourcemap payload field "minifiedFile" matches the minified file "a.js" for "multiple-source-map-typescript"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/lib/b.js"
+    And the sourcemap payload field "sourceMap" matches the source map "b.json" for "multiple-source-map-typescript"
+    And the sourcemap payload field "minifiedFile" matches the minified file "b.js" for "multiple-source-map-typescript"
 
   Scenario: Detected app version
     When I run the service "multiple-source-map-webpack" with the command
@@ -116,23 +116,23 @@ Feature: Node source map upload multiple
         --directory dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "4.5.6" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "4.5.6" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: codeBundleId support
     When I run the service "multiple-source-map-webpack" with the command
@@ -143,23 +143,23 @@ Feature: Node source map upload multiple
         --directory dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "codeBundleId" equals "r0124" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "codeBundleId" equals "r0124" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: Overwrite enabled
     When I run the service "multiple-source-map-webpack" with the command
@@ -171,23 +171,23 @@ Feature: Node source map upload multiple
         --endpoint http://maze-runner:9339
         --overwrite
       """
-    And I wait to receive 3 requests
+    And I wait to receive 3 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" equals "true" for all requests
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" equals "true" for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: A request will be retried on a server failure (500 status code)
     When I set the HTTP status code for the next request to 500
@@ -199,27 +199,27 @@ Feature: Node source map upload multiple
         --directory dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 4 requests
+    And I wait to receive 4 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
-    And the payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
-    When I discard the oldest request
-    And the payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
-    And the payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-cb48d68d.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-cb48d68d.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-cb48d68d.js" for "multiple-source-map-webpack"
+    When I discard the oldest sourcemap
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-d89fcf10.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-d89fcf10.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-d89fcf10.js" for "multiple-source-map-webpack"
 
   Scenario: A request will be retried up to 5 times on a server failure (500 status code)
     When I set the HTTP status code to 500
@@ -231,17 +231,17 @@ Feature: Node source map upload multiple
         --directory dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 5 requests
+    And I wait to receive 5 sourcemaps
     Then the last run docker command did not exit successfully
     And the Content-Type header is valid multipart form-data for all requests
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js" for all requests
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack" for all requests
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack" for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack" for all requests
 
   Scenario: A request will not be retried and further requests will not be made if the API key is invalid (401 status code)
     When I set the HTTP status code for the next request to 401
@@ -253,16 +253,16 @@ Feature: Node source map upload multiple
         --directory dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried and further requests will not be made if the source map is a duplicate (409 status code)
@@ -275,16 +275,16 @@ Feature: Node source map upload multiple
         --directory dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried and further requests will not be made if the bundle or source map is empty (422 status code)
@@ -297,16 +297,16 @@ Feature: Node source map upload multiple
         --directory dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried and further requests will not be made if request is bad (400 status code)
@@ -319,14 +319,14 @@ Feature: Node source map upload multiple
         --directory dist
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main-b3944033.js"
-    And the payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
-    And the payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main-b3944033.js"
+    And the sourcemap payload field "sourceMap" matches the source map "main-b3944033.json" for "multiple-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the minified file "main-b3944033.js" for "multiple-source-map-webpack"
     And the Content-Type header is valid multipart form-data

--- a/features/node-upload-one.feature
+++ b/features/node-upload-one.feature
@@ -255,3 +255,26 @@ Feature: Node source map upload one
     And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
     And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
+
+  Scenario: A request can set a timeout using the --idle-timeout flag
+    When I set the response delay to 5000 milliseconds
+    And I run the service "single-source-map-webpack" with the command
+      """
+      bugsnag-source-maps upload-node
+        --api-key 123
+        --app-version 2.0.0
+        --source-map dist/main.js.map
+        --bundle dist/main.js
+        --endpoint http://maze-runner:9339
+        --idle-timeout 0.0008 # approx 50ms in minutes
+      """
+    Then the last run docker command did not exit successfully
+    And the last run docker command output "The request timed out."
+    When I wait to receive 5 sourcemaps
+    And the Content-Type header is valid multipart form-data for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack" for all requests

--- a/features/node-upload-one.feature
+++ b/features/node-upload-one.feature
@@ -9,13 +9,13 @@ Feature: Node source map upload one
         --bundle dist/main.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -29,13 +29,13 @@ Feature: Node source map upload one
         --bundle dist/compiled.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/compiled.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-babel-node"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-babel-node"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/compiled.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-babel-node"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-babel-node"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -49,13 +49,13 @@ Feature: Node source map upload one
         --bundle dist/out.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/out.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-typescript"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-typescript"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/out.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-typescript"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-typescript"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -69,13 +69,13 @@ Feature: Node source map upload one
         --bundle dist/main.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "1.2.3"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "1.2.3"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -89,13 +89,13 @@ Feature: Node source map upload one
         --bundle dist/main.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "codeBundleId" equals "r0126"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "codeBundleId" equals "r0126"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -110,13 +110,13 @@ Feature: Node source map upload one
         --endpoint http://maze-runner:9339
         --overwrite
       """
-    And I wait to receive 1 request
-    Then the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "minifiedUrl" equals "dist/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And I wait to receive 1 sourcemap
+    Then the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
     And the last run docker command exited successfully
 
@@ -131,15 +131,15 @@ Feature: Node source map upload one
         --bundle dist/main.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 2 requests
+    And I wait to receive 2 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "dist/main.js" for all requests
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack" for all requests
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack" for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack" for all requests
 
   Scenario: A request will be retried up to 5 times on a server failure (500 status code)
     When I set the HTTP status code to 500
@@ -152,17 +152,17 @@ Feature: Node source map upload one
         --bundle dist/main.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 5 requests
+    And I wait to receive 5 sourcemaps
     Then the last run docker command did not exit successfully
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" is null for all requests
-    And the payload field "minifiedUrl" equals "dist/main.js" for all requests
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack" for all requests
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack" for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" is null for all requests
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack" for all requests
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack" for all requests
 
   Scenario: A request will not be retried if the API key is invalid (401 status code)
     When I set the HTTP status code for the next request to 401
@@ -175,16 +175,16 @@ Feature: Node source map upload one
         --bundle dist/main.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main.js" for all requests
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js" for all requests
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if the source map is a duplicate (409 status code)
@@ -198,16 +198,16 @@ Feature: Node source map upload one
         --bundle dist/main.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, use the \"overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if the bundle or source map is empty (422 status code)
@@ -221,16 +221,16 @@ Feature: Node source map upload one
         --bundle dist/main.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if request is bad (400 status code)
@@ -244,14 +244,14 @@ Feature: Node source map upload one
         --bundle dist/main.js
         --endpoint http://maze-runner:9339
       """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" is null
-    And the payload field "minifiedUrl" equals "dist/main.js"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
-    And the payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" is null
+    And the sourcemap payload field "minifiedUrl" equals "dist/main.js"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-webpack"
+    And the sourcemap payload field "minifiedFile" matches the expected minified file for "single-source-map-webpack"
     And the Content-Type header is valid multipart form-data

--- a/features/react-native-fetch.feature
+++ b/features/react-native-fetch.feature
@@ -190,3 +190,24 @@ Feature: React native source map fetch mode
     And the sourcemap payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
     And the sourcemap payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
+
+  Scenario: A request can set a timeout using the --idle-timeout flag
+    When I start the service "react-native-0-60-bundler"
+    And I wait for 2 seconds
+    And I set the response delay to 5000 milliseconds
+    And I run the service "react-native-0-60-fetch" with the command
+    """
+    bugsnag-source-maps upload-react-native
+      --api-key 123
+      --app-version 2.0.0
+      --endpoint http://maze-runner:9339
+      --fetch
+      --bundler-url http://react-native-0-60-bundler:9449
+      --platform ios
+      --idle-timeout 0.0008 # approx 50ms in minutes
+    """
+    Then the last run docker command did not exit successfully
+    And the last run docker command output "The request to http://react-native-0-60-bundler:9449 timed out."
+    # this is fetch mode so no sourcemaps should be uploaded because the request
+    # to the RN bundle server should timeout due to the idle-timeout
+    And I should receive no requests

--- a/features/react-native-fetch.feature
+++ b/features/react-native-fetch.feature
@@ -13,16 +13,16 @@ Feature: React native source map fetch mode
       --platform <platform>
       <flags>
     """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "dev" equals "<dev>"
-    And the payload field "platform" equals "<platform>"
-    And the payload field "sourceMap" matches the expected source map for "<expected directory>"
-    And the payload field "bundle" matches the expected bundle for "<expected directory>"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "dev" equals "<dev>"
+    And the sourcemap payload field "platform" equals "<platform>"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "<expected directory>"
+    And the sourcemap payload field "bundle" matches the expected bundle for "<expected directory>"
 
   Examples:
     | platform | dev   | flags | version | expected directory                  |
@@ -57,14 +57,14 @@ Feature: React native source map fetch mode
       --bundler-url http://react-native-0-60-bundler:9449
       --platform ios
     """
-    And I wait to receive 2 requests
+    And I wait to receive 2 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" equals "true" for all requests
-    And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios" for all requests
-    And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios" for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" equals "true" for all requests
+    And the sourcemap payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios" for all requests
+    And the sourcemap payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios" for all requests
 
   Scenario: A request will be retried up to 5 times on a server failure (500 status code)
     When I start the service "react-native-0-60-bundler"
@@ -80,16 +80,16 @@ Feature: React native source map fetch mode
       --bundler-url http://react-native-0-60-bundler:9449
       --platform ios
     """
-    And I wait to receive 5 requests
+    And I wait to receive 5 sourcemaps
     Then the last run docker command did not exit successfully
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" equals "true" for all requests
-    And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios" for all requests
-    And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios" for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" equals "true" for all requests
+    And the sourcemap payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios" for all requests
+    And the sourcemap payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios" for all requests
 
   Scenario: A request will not be retried if the API key is invalid (401 status code)
     When I start the service "react-native-0-60-bundler"
@@ -105,15 +105,15 @@ Feature: React native source map fetch mode
       --bundler-url http://react-native-0-60-bundler:9449
       --platform ios
     """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
-    And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
+    And the sourcemap payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if the source map is a duplicate (409 status code)
@@ -130,15 +130,15 @@ Feature: React native source map fetch mode
       --bundler-url http://react-native-0-60-bundler:9449
       --platform ios
     """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, remove the \"no-overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
-    And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
+    And the sourcemap payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if the bundle or source map is empty (422 status code)
@@ -155,15 +155,15 @@ Feature: React native source map fetch mode
       --bundler-url http://react-native-0-60-bundler:9449
       --platform ios
     """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
-    And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
+    And the sourcemap payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if request is bad (400 status code)
@@ -180,13 +180,13 @@ Feature: React native source map fetch mode
       --bundler-url http://react-native-0-60-bundler:9449
       --platform ios
     """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
-    And the payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "fetch-react-native-0-60-ios"
+    And the sourcemap payload field "bundle" matches the expected bundle for "fetch-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data

--- a/features/react-native-upload-one.feature
+++ b/features/react-native-upload-one.feature
@@ -11,16 +11,16 @@ Feature: React native source map upload one
       --platform <platform>
       <flags>
     """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "dev" equals "<dev>"
-    And the payload field "platform" equals "<platform>"
-    And the payload field "sourceMap" matches the expected source map for "<service>"
-    And the payload field "bundle" matches the expected bundle for "<service>"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "dev" equals "<dev>"
+    And the sourcemap payload field "platform" equals "<platform>"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "<service>"
+    And the sourcemap payload field "bundle" matches the expected bundle for "<service>"
 
   Examples:
     | platform | dev   | flags | service                                         |
@@ -53,14 +53,14 @@ Feature: React native source map upload one
       --bundle build/bundle.js
       --platform ios
     """
-    And I wait to receive 2 requests
+    And I wait to receive 2 sourcemaps
     Then the last run docker command exited successfully
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" equals "true" for all requests
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios" for all requests
-    And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios" for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" equals "true" for all requests
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios" for all requests
+    And the sourcemap payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios" for all requests
 
   Scenario: A request will be retried up to 5 times on a server failure (500 status code)
     When I set the HTTP status code to 500
@@ -74,16 +74,16 @@ Feature: React native source map upload one
       --bundle build/bundle.js
       --platform ios
     """
-    And I wait to receive 5 requests
+    And I wait to receive 5 sourcemaps
     Then the last run docker command did not exit successfully
     And the last run docker command output "A server side error occurred while processing the upload."
     And the last run docker command output "HTTP status 500 received from upload API"
     And the Content-Type header is valid multipart form-data for all requests
-    And the payload field "apiKey" equals "123" for all requests
-    And the payload field "appVersion" equals "2.0.0" for all requests
-    And the payload field "overwrite" equals "true" for all requests
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios" for all requests
-    And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios" for all requests
+    And the sourcemap payload field "apiKey" equals "123" for all requests
+    And the sourcemap payload field "appVersion" equals "2.0.0" for all requests
+    And the sourcemap payload field "overwrite" equals "true" for all requests
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios" for all requests
+    And the sourcemap payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios" for all requests
 
   Scenario: A request will not be retried if the API key is invalid (401 status code)
     When I set the HTTP status code for the next request to 401
@@ -97,15 +97,15 @@ Feature: React native source map upload one
       --bundle build/bundle.js
       --platform ios
     """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The provided API key was invalid."
     And the last run docker command output "HTTP status 401 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
-    And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
+    And the sourcemap payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if the source map is a duplicate (409 status code)
@@ -120,15 +120,15 @@ Feature: React native source map upload one
       --bundle build/bundle.js
       --platform ios
     """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "A source map matching the same criteria has already been uploaded. If you want to replace it, remove the \"no-overwrite\" flag."
     And the last run docker command output "HTTP status 409 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
-    And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
+    And the sourcemap payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if the bundle or source map is empty (422 status code)
@@ -143,15 +143,15 @@ Feature: React native source map upload one
       --bundle build/bundle.js
       --platform ios
     """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The uploaded source map was empty."
     And the last run docker command output "HTTP status 422 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
-    And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
+    And the sourcemap payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data
 
   Scenario: A request will not be retried if request is bad (400 status code)
@@ -166,13 +166,13 @@ Feature: React native source map upload one
       --bundle build/bundle.js
       --platform ios
     """
-    And I wait to receive 1 request
+    And I wait to receive 1 sourcemap
     Then the last run docker command did not exit successfully
     And the last run docker command output "The request was rejected by the server as invalid."
     And the last run docker command output "HTTP status 400 received from upload API"
-    And the payload field "apiKey" equals "123"
-    And the payload field "appVersion" equals "2.0.0"
-    And the payload field "overwrite" equals "true"
-    And the payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
-    And the payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
+    And the sourcemap payload field "apiKey" equals "123"
+    And the sourcemap payload field "appVersion" equals "2.0.0"
+    And the sourcemap payload field "overwrite" equals "true"
+    And the sourcemap payload field "sourceMap" matches the expected source map for "single-source-map-react-native-0-60-ios"
+    And the sourcemap payload field "bundle" matches the expected bundle for "single-source-map-react-native-0-60-ios"
     And the Content-Type header is valid multipart form-data

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -1,12 +1,12 @@
 Then("the Content-Type header is valid multipart form-data") do
   expected = /^multipart\/form-data; boundary=--------------------------\d+$/
-  actual = Server.current_request[:request]["content-type"]
+  actual = Maze::Server.sourcemaps.current[:request]["content-type"]
 
   assert_match(expected, actual)
 end
 
 Then("the Content-Type header is valid multipart form-data for all requests") do
-  Server.stored_requests.each do |request|
+  Maze::Server.sourcemaps.all.each do |request|
     expected = /^multipart\/form-data; boundary=--------------------------\d+$/
     actual = request[:request]["content-type"]
 
@@ -22,8 +22,8 @@ def read_expected_file(fixture, file_name)
   File.read(path)
 end
 
-def get_form_data_as_string(field, request = Server.current_request)
-  form_data = read_key_path(request[:body], field)
+def get_form_data_as_string(field, request = Maze::Server.sourcemaps.current)
+  form_data = Maze::Helper.read_key_path(request[:body], field)
 
   assert_instance_of(
     WEBrick::HTTPUtils::FormData,
@@ -34,45 +34,45 @@ def get_form_data_as_string(field, request = Server.current_request)
   form_data.to_s.force_encoding('UTF-8')
 end
 
-def assert_source_map_matches(field, file_name, fixture, request = Server.current_request)
+def assert_source_map_matches(field, file_name, fixture, request = Maze::Server.sourcemaps.current)
   expected = JSON.parse(read_expected_file(fixture, file_name))
   actual = JSON.parse(get_form_data_as_string(field, request))
 
   assert_equal(expected, actual)
 end
 
-Then("the payload field {string} matches the expected source map for {string}") do |field, fixture|
+Then("the sourcemap payload field {string} matches the expected source map for {string}") do |field, fixture|
   steps %Q{
-    Then the payload field "#{field}" matches the source map "source-map.json" for "#{fixture}"
+    Then the sourcemap payload field "#{field}" matches the source map "source-map.json" for "#{fixture}"
   }
 end
 
-Then("the payload field {string} matches the expected minified file for {string}") do |field, fixture|
+Then("the sourcemap payload field {string} matches the expected minified file for {string}") do |field, fixture|
   steps %Q{
-    Then the payload field "#{field}" matches the minified file "minified-file.js" for "#{fixture}"
+    Then the sourcemap payload field "#{field}" matches the minified file "minified-file.js" for "#{fixture}"
   }
 end
 
-Then("the payload field {string} matches the expected bundle for {string}") do |field, fixture|
+Then("the sourcemap payload field {string} matches the expected bundle for {string}") do |field, fixture|
   steps %Q{
-    Then the payload field "#{field}" matches the minified file "bundle.js" for "#{fixture}"
+    Then the sourcemap payload field "#{field}" matches the minified file "bundle.js" for "#{fixture}"
   }
 end
 
-Then("the payload field {string} matches the source map {string} for {string}") do |field, file_name, fixture|
+Then("the sourcemap payload field {string} matches the source map {string} for {string}") do |field, file_name, fixture|
   assert_source_map_matches(field, file_name, fixture)
 end
 
-Then("the payload field {string} matches the minified file {string} for {string}") do |field, file_name, fixture|
+Then("the sourcemap payload field {string} matches the minified file {string} for {string}") do |field, file_name, fixture|
   expected = read_expected_file(fixture, file_name).chomp
   actual = get_form_data_as_string(field)
 
   assert_equal(expected, actual)
 end
 
-Then("the payload field {string} equals {string} for all requests") do |field, expected|
-  Server.stored_requests.each_with_index do |request, index|
-    actual = read_key_path(request[:body], field)
+Then("the sourcemap payload field {string} equals {string} for all requests") do |field, expected|
+  Maze::Server.sourcemaps.all.each_with_index do |request, index|
+    actual = Maze::Helper.read_key_path(request[:body], field)
 
     assert_equal(
       expected,
@@ -82,9 +82,9 @@ Then("the payload field {string} equals {string} for all requests") do |field, e
   end
 end
 
-Then("the payload field {string} is null for all requests") do |field|
-  Server.stored_requests.each_with_index do |request, index|
-    actual = read_key_path(request[:body], field)
+Then("the sourcemap payload field {string} is null for all requests") do |field|
+  Maze::Server.sourcemaps.all.each_with_index do |request, index|
+    actual = Maze::Helper.read_key_path(request[:body], field)
 
     assert_nil(
       actual,
@@ -93,32 +93,32 @@ Then("the payload field {string} is null for all requests") do |field|
   end
 end
 
-Then("the payload field {string} matches the expected source map for {string} for all requests") do |field, fixture|
+Then("the sourcemap payload field {string} matches the expected source map for {string} for all requests") do |field, fixture|
   steps %Q{
-    Then the payload field "#{field}" matches the source map "source-map.json" for "#{fixture}" for all requests
+    Then the sourcemap payload field "#{field}" matches the source map "source-map.json" for "#{fixture}" for all requests
   }
 end
 
-Then("the payload field {string} matches the expected minified file for {string} for all requests") do |field, fixture|
+Then("the sourcemap payload field {string} matches the expected minified file for {string} for all requests") do |field, fixture|
   steps %Q{
-    Then the payload field "#{field}" matches the minified file "minified-file.js" for "#{fixture}" for all requests
+    Then the sourcemap payload field "#{field}" matches the minified file "minified-file.js" for "#{fixture}" for all requests
   }
 end
 
-Then("the payload field {string} matches the expected bundle for {string} for all requests") do |field, fixture|
+Then("the sourcemap payload field {string} matches the expected bundle for {string} for all requests") do |field, fixture|
   steps %Q{
-    Then the payload field "#{field}" matches the minified file "bundle.js" for "#{fixture}" for all requests
+    Then the sourcemap payload field "#{field}" matches the minified file "bundle.js" for "#{fixture}" for all requests
   }
 end
 
-Then("the payload field {string} matches the source map {string} for {string} for all requests") do |field, file_name, fixture|
-  Server.stored_requests.each do |request|
+Then("the sourcemap payload field {string} matches the source map {string} for {string} for all requests") do |field, file_name, fixture|
+  Maze::Server.sourcemaps.all.each do |request|
     assert_source_map_matches(field, file_name, fixture, request)
   end
 end
 
-Then("the payload field {string} matches the minified file {string} for {string} for all requests") do |field, file_name, fixture|
-  Server.stored_requests.each do |request|
+Then("the sourcemap payload field {string} matches the minified file {string} for {string} for all requests") do |field, file_name, fixture|
+  Maze::Server.sourcemaps.all.each do |request|
     expected = read_expected_file(fixture, file_name).chomp
     actual = get_form_data_as_string(field, request)
 
@@ -129,7 +129,7 @@ end
 # This is useful for debugging React Native because the source maps & bundles
 # are too big to for MR to display, even in debug mode
 counts = Hash.new(0)
-Then("I write the payload field {string} to disk") do |field|
+Then("I write the sourcemap payload field {string} to disk") do |field|
   counts[field] += 1
 
   File.open("#{__dir__}/actual-#{field}-#{counts[field]}", "w") do |file|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,8 +13,11 @@ end
 
 AfterConfiguration do |_config|
   copy_package
+
+  Maze.config.file_log = false
+  Maze.config.log_requests = true
 end
 
 Before do
-  Docker.compose_project_name = "#{rand.to_s}:#{Time.new.strftime("%s")}"
+  Maze::Docker.compose_project_name = "#{rand.to_s}:#{Time.new.strftime("%s")}"
 end

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -37,16 +37,25 @@ interface ReactNativePayload {
   bundle: File
 }
 
+interface RequestOptions {
+  idleTimeout?: number
+}
+
 const MAX_ATTEMPTS = 5
 const RETRY_INTERVAL_MS = parseInt(process.env.BUGSNAG_RETRY_INTERVAL_MS as string) || 1000
-const TIMEOUT_MS = parseInt(process.env.BUGSNAG_TIMEOUT_MS as string) || 30000
+const DEFAULT_TIMEOUT_MS = parseInt(process.env.BUGSNAG_TIMEOUT_MS as string) || 60000
 
-export default async function request (endpoint: string, payload: Payload, requestOpts: http.RequestOptions): Promise<void> {
+export default async function request (
+  endpoint: string,
+  payload: Payload,
+  requestOpts: http.RequestOptions,
+  options: RequestOptions = {}
+): Promise<void> {
   let attempts = 0
   const go = async (): Promise<void> => {
     try {
       attempts++
-      await send(endpoint, payload, requestOpts)
+      await send(endpoint, payload, requestOpts, options)
     } catch (err) {
       if (err && err.isRetryable !== false && attempts < MAX_ATTEMPTS) {
         await new Promise((resolve) => setTimeout(resolve, RETRY_INTERVAL_MS))
@@ -109,7 +118,12 @@ function appendReactNativeFormData(formData: FormData, payload: ReactNativePaylo
   return formData
 }
 
-export async function send (endpoint: string, payload: Payload, requestOpts: http.RequestOptions): Promise<void> {
+export async function send (
+  endpoint: string,
+  payload: Payload,
+  requestOpts: http.RequestOptions,
+  options: RequestOptions = {}
+): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const formData = createFormData(payload)
 
@@ -153,7 +167,7 @@ export async function send (endpoint: string, payload: Payload, requestOpts: htt
     formData.pipe(req)
 
     addErrorHandler(req, reject)
-    addTimeout(req, reject)
+    addTimeout(req, reject, options)
   })
 }
 
@@ -169,7 +183,7 @@ export function isRetryable (status?: number): boolean {
     )
 }
 
-export function fetch(endpoint: string): Promise<string> {
+export function fetch(endpoint: string, options: RequestOptions = {}): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const parsedUrl = url.parse(endpoint)
 
@@ -197,7 +211,7 @@ export function fetch(endpoint: string): Promise<string> {
     })
 
     addErrorHandler(req, reject)
-    addTimeout(req, reject)
+    addTimeout(req, reject, options)
   })
 }
 
@@ -218,8 +232,18 @@ function addErrorHandler(req: http.ClientRequest, reject: (reason: NetworkError)
   })
 }
 
-function addTimeout(req: http.ClientRequest, reject: (reason: NetworkError) => void): void {
-  req.setTimeout(TIMEOUT_MS, () => {
+const minutesToMilliseconds = (minutes: number): number => minutes * 60 * 1000
+
+function addTimeout(
+  req: http.ClientRequest,
+  reject: (reason: NetworkError) => void,
+  options: RequestOptions
+): void {
+  const timeout = options.idleTimeout
+    ? minutesToMilliseconds(options.idleTimeout)
+    : DEFAULT_TIMEOUT_MS
+
+  req.setTimeout(timeout, () => {
     const err = new NetworkError('Connection timed out')
     err.code = NetworkErrorCode.TIMEOUT
     reject(err)

--- a/src/commands/CommandDefinitions.ts
+++ b/src/commands/CommandDefinitions.ts
@@ -5,5 +5,6 @@ export const commonCommandDefs = [
   { name: 'project-root', type: String, description: 'the top level directory of your project (defaults to the current directory)' },
   { name: 'endpoint', type: String, description: 'customize the endpoint for Bugsnag On-Premise' },
   { name: 'quiet', type: Boolean, description: 'less verbose logging' },
-  { name: 'code-bundle-id', type: String }
+  { name: 'code-bundle-id', type: String },
+  { name: 'idle-timeout', type: Number, description: 'idle timeout for HTTP requests in minutes' }
 ]

--- a/src/commands/UploadBrowserCommand.ts
+++ b/src/commands/UploadBrowserCommand.ts
@@ -50,6 +50,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
         endpoint: browserOpts.endpoint,
         detectAppVersion: browserOpts.detectAppVersion,
         codeBundleId: browserOpts.codeBundleId,
+        idleTimeout: browserOpts.idleTimeout,
         logger
       })
     } else {
@@ -64,6 +65,7 @@ export default async function uploadBrowser (argv: string[], opts: Record<string
         endpoint: browserOpts.endpoint,
         detectAppVersion: browserOpts.detectAppVersion,
         codeBundleId: browserOpts.codeBundleId,
+        idleTimeout: browserOpts.idleTimeout,
         logger
       })
     }

--- a/src/commands/UploadNodeCommand.ts
+++ b/src/commands/UploadNodeCommand.ts
@@ -41,6 +41,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
         endpoint: nodeOpts.endpoint,
         detectAppVersion: nodeOpts.detectAppVersion,
         codeBundleId: nodeOpts.codeBundleId,
+        idleTimeout: nodeOpts.idleTimeout,
         logger
       })
     } else {
@@ -54,6 +55,7 @@ export default async function uploadNode (argv: string[], opts: Record<string, u
         endpoint: nodeOpts.endpoint,
         detectAppVersion: nodeOpts.detectAppVersion,
         codeBundleId: nodeOpts.codeBundleId,
+        idleTimeout: nodeOpts.idleTimeout,
         logger
       })
     }

--- a/src/commands/UploadReactNativeCommand.ts
+++ b/src/commands/UploadReactNativeCommand.ts
@@ -55,6 +55,7 @@ export default async function uploadReactNative (argv: string[], opts: Record<st
         endpoint: reactNativeOpts.endpoint,
         bundlerUrl: reactNativeOpts.bundlerUrl,
         bundlerEntryPoint: reactNativeOpts.bundlerEntryPoint,
+        idleTimeout: reactNativeOpts.idleTimeout,
         logger
       })
     } else {
@@ -71,6 +72,7 @@ export default async function uploadReactNative (argv: string[], opts: Record<st
         platform: reactNativeOpts.platform,
         dev: reactNativeOpts.dev,
         endpoint: reactNativeOpts.endpoint,
+        idleTimeout: reactNativeOpts.idleTimeout,
         logger
       })
     }

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -32,7 +32,8 @@ interface UploadSingleOpts {
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
-  detectAppVersion?: boolean,
+  detectAppVersion?: boolean
+  idleTimeout?: number
   requestOpts?: http.RequestOptions
   logger?: Logger
 }
@@ -52,6 +53,7 @@ export async function uploadOne ({
   sourceMap,
   appVersion,
   codeBundleId,
+  idleTimeout,
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -117,7 +119,7 @@ export async function uploadOne ({
       minifiedFile: (bundleContent && fullBundlePath) ? new File(fullBundlePath, bundleContent) : undefined,
       sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
       overwrite: overwrite
-    }, requestOpts)
+    }, requestOpts, { idleTimeout })
 
     const uploadedFiles = (bundleContent && fullBundlePath) ? `${sourceMap} and ${bundle}` : sourceMap
 
@@ -141,7 +143,8 @@ interface UploadMultipleOpts {
   overwrite?: boolean
   projectRoot?: string
   endpoint?: string
-  detectAppVersion?: boolean,
+  detectAppVersion?: boolean
+  idleTimeout?: number
   requestOpts?: http.RequestOptions
   logger?: Logger
 }
@@ -161,6 +164,7 @@ export async function uploadMultiple ({
   directory,
   appVersion,
   codeBundleId,
+  idleTimeout,
   overwrite = false,
   detectAppVersion = false,
   projectRoot = process.cwd(),
@@ -249,7 +253,7 @@ export async function uploadMultiple ({
         minifiedFile: (bundleContent && fullBundlePath) ? new File(fullBundlePath, bundleContent) : undefined,
         sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
         overwrite: overwrite
-      }, requestOpts)
+      }, requestOpts, { idleTimeout })
 
       const uploadedFiles = (bundleContent && fullBundlePath) ? `${sourceMap} and ${bundlePath}` : sourceMap
 

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -34,6 +34,7 @@ interface UploadSingleOpts {
   detectAppVersion?: boolean
   requestOpts?: http.RequestOptions
   logger?: Logger
+  idleTimeout?: number
 }
 
 function validateOneOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
@@ -50,6 +51,7 @@ export async function uploadOne ({
   sourceMap,
   appVersion,
   codeBundleId,
+  idleTimeout,
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -110,7 +112,7 @@ export async function uploadOne ({
       minifiedFile: new File(fullBundlePath, bundleContent),
       sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
       overwrite: overwrite
-    }, requestOpts)
+    }, requestOpts, { idleTimeout })
     logger.success(`Success, uploaded ${sourceMap} and ${bundle} to ${url} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {
@@ -133,6 +135,7 @@ interface UploadMultipleOpts {
   detectAppVersion?: boolean
   requestOpts?: http.RequestOptions
   logger?: Logger
+  idleTimeout?: number
 }
 
 function validateMultipleOpts (opts: Record<string, unknown>, unknownArgs: Record<string, unknown>) {
@@ -148,6 +151,7 @@ export async function uploadMultiple ({
   directory,
   appVersion,
   codeBundleId,
+  idleTimeout,
   overwrite = false,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -235,7 +239,7 @@ export async function uploadMultiple ({
         minifiedFile: (bundleContent && fullBundlePath) ? new File(fullBundlePath, bundleContent) : undefined,
         sourceMap: new File(fullSourceMapPath, JSON.stringify(transformedSourceMap)),
         overwrite: overwrite
-      }, requestOpts)
+      }, requestOpts, { idleTimeout })
 
       const uploadedFiles = (bundleContent && fullBundlePath) ? `${sourceMap} and ${bundlePath}` : sourceMap
 

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -35,6 +35,7 @@ interface CommonUploadOpts {
   endpoint?: string
   requestOpts?: http.RequestOptions
   logger?: Logger
+  idleTimeout?: number
 }
 
 interface UploadSingleOpts extends CommonUploadOpts {
@@ -60,6 +61,7 @@ export async function uploadOne ({
   codeBundleId,
   appVersionCode,
   appBundleVersion,
+  idleTimeout,
   overwrite = true,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -114,7 +116,7 @@ export async function uploadOne ({
       dev,
       ...marshalledVersions,
       overwrite
-    }, requestOpts)
+    }, requestOpts, { idleTimeout })
     logger.success(`Success, uploaded ${sourceMap} and ${bundle} to ${url} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {
@@ -147,6 +149,7 @@ export async function fetchAndUploadOne ({
   codeBundleId,
   appVersionCode,
   appBundleVersion,
+  idleTimeout,
   overwrite = true,
   projectRoot = process.cwd(),
   endpoint = DEFAULT_UPLOAD_ORIGIN,
@@ -194,7 +197,7 @@ export async function fetchAndUploadOne ({
 
   try {
     logger.debug(`Fetching source map from ${sourceMapUrl}`)
-    sourceMap = await fetch(sourceMapUrl)
+    sourceMap = await fetch(sourceMapUrl, { idleTimeout })
   } catch (e) {
     logger.error(
       formatFetchError(e, bundlerUrl, bundlerEntryPoint), e
@@ -204,7 +207,7 @@ export async function fetchAndUploadOne ({
 
   try {
     logger.debug(`Fetching bundle from ${bundleUrl}`)
-    bundle = await fetch(bundleUrl)
+    bundle = await fetch(bundleUrl, { idleTimeout })
   } catch (e) {
     logger.error(
       formatFetchError(e, bundlerUrl, bundlerEntryPoint), e
@@ -231,7 +234,7 @@ export async function fetchAndUploadOne ({
       dev,
       ...marshalledVersions,
       overwrite
-    }, requestOpts)
+    }, requestOpts, { idleTimeout })
     logger.success(`Success, uploaded ${entryPoint}.js.map to ${url} in ${(new Date()).getTime() - start}ms`)
   } catch (e) {
     if (e.cause) {

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -38,7 +38,8 @@ test('uploadOne(): dispatches a request with the correct params', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -63,7 +64,8 @@ test('uploadOne(): dispatches a request with the correct params (no bundle)', as
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -82,7 +84,8 @@ test('uploadOne(): codeBundleId', async () => {
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r0001' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -348,7 +351,8 @@ test('uploadOne(): custom endpoint (origin only)', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -374,7 +378,8 @@ test('uploadOne(): custom endpoint (absolute)', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -426,7 +431,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/2.e5bb21a6.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -444,7 +450,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/3.1b8b4fc7.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -462,7 +469,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/main.286ac573.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -480,7 +488,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/runtime-main.ad66c902.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -512,7 +521,8 @@ test('uploadMultiple(): success passing appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/2.e5bb21a6.chunk.js',
       appVersion: '4.5.6'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -530,7 +540,8 @@ test('uploadMultiple(): success passing appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/3.1b8b4fc7.chunk.js',
       appVersion: '4.5.6'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -548,7 +559,8 @@ test('uploadMultiple(): success passing appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/main.286ac573.chunk.js',
       appVersion: '4.5.6'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -566,7 +578,8 @@ test('uploadMultiple(): success passing appVersion', async () => {
       minifiedUrl: 'http://mybundle.jim/static/js/runtime-main.ad66c902.js',
       appVersion: '4.5.6'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -586,22 +599,26 @@ test('uploadMultiple(): success with codeBundleId', async () => {
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012'}),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -634,7 +651,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'http://mybundle.jim/static/js/2.e5bb21a6.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -652,7 +670,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'http://mybundle.jim/static/js/3.1b8b4fc7.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -670,7 +689,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'http://mybundle.jim/static/js/main.286ac573.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -688,7 +708,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'http://mybundle.jim/static/js/runtime-main.ad66c902.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 

--- a/src/uploaders/__test__/NodeUploader.test.ts
+++ b/src/uploaders/__test__/NodeUploader.test.ts
@@ -37,7 +37,8 @@ test('uploadOne(): dispatches a request with the correct params', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -62,7 +63,8 @@ test('uploadOne(): dispatches a request with the correct params and detected app
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -183,7 +185,8 @@ test('uploadOne(): custom endpoint (origin only)', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -207,7 +210,8 @@ test('uploadOne(): custom endpoint (absolute)', async () => {
       overwrite: false,
       sourceMap: expect.any(Object)
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -251,7 +255,8 @@ test('uploadOne(): codeBundleId', async () => {
       sourceMap: expect.any(Object),
       codeBundleId: 'r0001'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -282,7 +287,8 @@ test('uploadMultiple(): success', async () => {
       minifiedUrl: 'dist/a.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -300,7 +306,8 @@ test('uploadMultiple(): success', async () => {
       minifiedUrl: 'dist/b.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -318,7 +325,8 @@ test('uploadMultiple(): success', async () => {
       minifiedUrl: 'dist/index.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -349,7 +357,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'build/static/js/2.e5bb21a6.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -367,7 +376,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'build/static/js/3.1b8b4fc7.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -385,7 +395,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'build/static/js/main.286ac573.chunk.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -403,7 +414,8 @@ test('uploadMultiple(): success with detected appVersion', async () => {
       minifiedUrl: 'build/static/js/runtime-main.ad66c902.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -421,22 +433,26 @@ test('uploadMultiple(): success with codeBundleId', async () => {
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012'}),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
     expect.objectContaining({ codeBundleId: 'r00012' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -467,7 +483,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'dist/a.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -485,7 +502,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'dist/b.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://upload.bugsnag.com/sourcemap',
@@ -503,7 +521,8 @@ test('uploadMultiple(): success using absolute path for "directory"', async () =
       minifiedUrl: 'dist/index.js',
       appVersion: '1.2.3'
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -45,7 +45,8 @@ test('uploadOne(): dispatches a request with the correct params for Android with
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -76,7 +77,8 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -109,7 +111,8 @@ test('uploadOne(): dispatches a request with the correct params for Android with
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -142,7 +145,8 @@ test('uploadOne(): dispatches a request with the correct params for iOS with app
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -174,7 +178,8 @@ test('uploadOne(): dispatches a request with the correct params for Android with
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest.mock.calls[0][1]).toEqual(expect.not.objectContaining({ appVersionCode: '3.2.1' }))
 })
@@ -207,7 +212,8 @@ test('uploadOne(): dispatches a request with the correct params for iOS with cod
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
   expect(mockedRequest.mock.calls[0][1]).toEqual(expect.not.objectContaining({ appBundleVersion: '4.5.6' }))
 })
@@ -328,7 +334,8 @@ test('uploadOne(): custom endpoint (absolute)', async () => {
   expect(mockedRequest).toHaveBeenCalledWith(
     'https://bugsnag.my-company.com/source-map-custom',
     expect.objectContaining({ apiKey: '123' }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -382,8 +389,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=false')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=false', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=false', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -397,7 +404,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
@@ -429,8 +437,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=ios&dev=false')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=ios&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=ios&dev=false', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=ios&dev=false', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -444,7 +452,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
@@ -475,8 +484,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -490,7 +499,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for Andr
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -517,8 +527,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=ios&dev=true')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=ios&dev=true')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=ios&dev=true', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=ios&dev=true', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -532,7 +542,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params for iOS 
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 })
 
@@ -561,8 +572,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -576,7 +587,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
@@ -609,8 +621,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -624,7 +636,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
@@ -657,8 +670,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
   })
 
   expect(mockedFetch).toHaveBeenCalledTimes(2)
-  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false')
-  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false')
+  expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/cool-app.js.map?platform=ios&dev=false', { idleTimeout: undefined })
+  expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/cool-app.bundle?platform=ios&dev=false', { idleTimeout: undefined })
 
   expect(mockedRequest).toHaveBeenCalledTimes(1)
   expect(mockedRequest).toHaveBeenCalledWith(
@@ -672,7 +685,8 @@ test('fetchAndUploadOne(): dispatches a request with the correct params with cus
       sourceMap: expect.any(File),
       bundle: expect.any(File),
     }),
-    expect.objectContaining({})
+    {},
+    { idleTimeout: undefined }
   )
 
   expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining(
@@ -703,7 +717,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (generic Error)'
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
@@ -735,7 +749,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (generic Network
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
@@ -769,7 +783,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (connection refu
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('Unable to connect to http://react-native-bundler:1234. Is the server running?'),
@@ -803,7 +817,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (server error)',
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining("Received an error from the server at http://react-native-bundler:1234. Does the entry point file 'index.js' exist?"),
@@ -837,7 +851,7 @@ test('fetchAndUploadOne(): Fetch mode failure to get source map (timeout)', asyn
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(1)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('The request to http://react-native-bundler:1234 timed out.'),
@@ -873,8 +887,8 @@ test('fethchAndUploadOne(): Fetch mode failure to get bundle (generic Error)', a
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(2)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
@@ -910,8 +924,8 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (generic NetworkErro
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(2)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('An unexpected error occurred during the request to http://react-native-bundler:1234'),
@@ -949,8 +963,8 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (connection refused)
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(2)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('Unable to connect to http://react-native-bundler:1234. Is the server running?'),
@@ -988,8 +1002,8 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (server error)', asy
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(2)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining("Received an error from the server at http://react-native-bundler:1234. Does the entry point file 'index.js' exist?"),
@@ -1027,8 +1041,8 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (timeout)', async ()
     })
   } catch (e) {
     expect(mockedFetch).toHaveBeenCalledTimes(2)
-    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true')
-    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true')
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'http://react-native-bundler:1234/index.js.map?platform=android&dev=true', { idleTimeout: undefined })
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'http://react-native-bundler:1234/index.bundle?platform=android&dev=true', { idleTimeout: undefined })
     expect(mockedRequest).not.toHaveBeenCalled()
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.stringContaining('The request to http://react-native-bundler:1234 timed out.'),


### PR DESCRIPTION
## 2.3.0 (2021-08-04)

- Add `--idle-timeout` flag to control the HTTP request timeout ([see Node documentation](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback)) [#74](https://github.com/bugsnag/bugsnag-source-maps/pull/74)
- Increase the default HTTP request timeout to 10 minutes (from 5 minutes) [#74](https://github.com/bugsnag/bugsnag-source-maps/pull/74)
