### PR TITLE
added support for monorepo

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
 
-require('../dist/bin/cli.js').default(process.argv)
+const { dirname, join } = require('path')
+
+require(join(
+  dirname(require.resolve('@bugsnag/source-maps/package.json')),
+  'dist/bin/cli.js'
+)).default(process.argv)


### PR DESCRIPTION
## Goal

When we setup bugsnag react native package, it doesn't support 100% monorepo. Apparently, the best option right now to support that is to perform hoisting on packages (if you are using yarn workspaces). The idea is to support a standalone package, but also monorepo.

## Design

To better locate the bugsnag sourcemap package. When executing under the xcode build phases, the relative path will not work if we are working under monorepo projects. With this approach, the problem gets solved.

## Changeset

Changed binary in order to target the right package location

## Testing

Right now i just tested on my project. I would need some guidance in order to test it properly and not affect other developers. Feedback is needed 😄 