### PR TITLE
Normalise path separators for Webpack paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- Normalise path separators for Webpack paths on Windows [#95](https://github.com/bugsnag/bugsnag-source-maps/pull/95)
+
 ## 2.3.2 (2024-03-04)
 
 ### Security

--- a/src/transformers/StripProjectRoot.ts
+++ b/src/transformers/StripProjectRoot.ts
@@ -24,10 +24,17 @@ function strip (sourceMapPath: string, map: UnsafeSourceMap, projectRoot: string
   map.sources = map.sources.map(s => {
     // leave sources for virtual webpack files untouched
     if (/^webpack:\/\/(.*)\/webpack/.test(s)) return s
+
+    // If the source path is a webpack path and we are running on Windows,
+    // we normalize the path separators to URI format
+    const isWebPackOnWindows = s.indexOf('webpack') > -1 && process.platform === 'win32'
+
     const absoluteSourcePath = path.resolve(
       path.dirname(sourceMapPath),
       s.replace(/webpack:\/\/.*\/\.\//, `${projectRoot}/`)
     )
-    return absoluteSourcePath.replace(projectRoot, '').replace(/^(\/|\\)/, '')
+
+    const strippedSourcePath = absoluteSourcePath.replace(projectRoot, '').replace(/^(\/|\\)/, '')
+    return isWebPackOnWindows ? strippedSourcePath.replace(/\\/g, '/') : strippedSourcePath
   })
 }

--- a/src/transformers/__test__/StripProjectRoot.test.ts
+++ b/src/transformers/__test__/StripProjectRoot.test.ts
@@ -26,7 +26,7 @@ test('StripProjectRoot transformer: webpack example', async () => {
   const sourceMapJson = JSON.parse(await fs.readFile(absolutePath, 'utf-8'))
   await StripProjectRoot(absolutePath, sourceMapJson, projectRoot, noopLogger)
   expect(sourceMapJson.sources).toStrictEqual([
-    path.join('lib', 'a.js'),
+    'lib/a.js',
     'webpack:///webpack/bootstrap',
     'index.js'
   ])
@@ -38,7 +38,7 @@ test('StripProjectRoot transformer: webpack example (synthetic sections)', async
   const sourceMapJson = { sections: [ { map: JSON.parse(await fs.readFile(absolutePath, 'utf-8')) } ] }
   await StripProjectRoot(absolutePath, sourceMapJson, projectRoot, noopLogger)
   expect(sourceMapJson.sections[0].map.sources).toStrictEqual([
-    path.join('lib', 'a.js'),
+    'lib/a.js',
     'webpack:///webpack/bootstrap',
     'index.js'
   ])
@@ -50,7 +50,7 @@ test('StripProjectRoot transformer: webpack example with namespace', async () =>
   const sourceMapJson = { sections: [ { map: JSON.parse(await fs.readFile(absolutePath, 'utf-8')) } ] }
   await StripProjectRoot(absolutePath, sourceMapJson, projectRoot, noopLogger)
   expect(sourceMapJson.sections[0].map.sources).toStrictEqual([
-    path.join('lib', 'a.js'),
+    'lib/a.js',
     'webpack://this-package-name-is-used-in-the-source-paths/webpack/bootstrap',
     'index.js'
   ])


### PR DESCRIPTION
## Goal

Updates `StripProjectRoot` to preserve the correct path separators for Webpack source maps when running on Windows.

The `StripProjectRoot` transformation uses `path`, which uses platform-specific path separators. This means that when the tool is run on Windows, Webpack source paths are incorrectly converted to Windows-style path separators.

## Design

If we detect that the tool is running on Windows and the source map path is a Webpack path, normalise the path separators to URI format (`/`)

## Testing

Updated webpack unit tests assertions to check for the correct path separator - although CI runs on both Windows and Linux, the unit test assertions used `path.join` and so were also platform-specific.