### PR TITLE
Set default endpoints based on API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TBD
 
+- Set default endpoints based on API key [#100](https://github.com/bugsnag/bugsnag-source-maps/pull/100)
+
 ### Fixed
 
 - Normalise path separators for Webpack paths on Windows [#95](https://github.com/bugsnag/bugsnag-source-maps/pull/95)

--- a/src/uploaders/BrowserUploader.ts
+++ b/src/uploaders/BrowserUploader.ts
@@ -19,7 +19,9 @@ import {
   validateNoUnknownArgs
 } from './lib/InputValidators'
 
-import { DEFAULT_UPLOAD_ORIGIN, buildEndpointUrl } from './lib/EndpointUrl'
+import { DEFAULT_UPLOAD_ORIGIN,
+         buildEndpointUrl,
+         selectUploadOrigin }        from './lib/EndpointUrl'
 const UPLOAD_PATH = '/sourcemap'
 
 interface UploadSingleOpts {
@@ -78,6 +80,7 @@ export async function uploadOne ({
   }, unknownArgs as Record<string, unknown>)
 
   logger.info(`Preparing upload of browser source map for "${bundleUrl}"`)
+  endpoint = selectUploadOrigin(apiKey, endpoint)
 
   let url
   try {
@@ -188,6 +191,8 @@ export async function uploadMultiple ({
   }, unknownArgs as Record<string, unknown>)
 
   logger.info(`Preparing upload of browser source maps for "${baseUrl}"`)
+
+  endpoint = selectUploadOrigin(apiKey, endpoint)
 
   let url
   try {

--- a/src/uploaders/NodeUploader.ts
+++ b/src/uploaders/NodeUploader.ts
@@ -19,7 +19,11 @@ import {
   validateNoUnknownArgs
 } from './lib/InputValidators'
 
-import { DEFAULT_UPLOAD_ORIGIN, buildEndpointUrl } from './lib/EndpointUrl'
+import {
+  DEFAULT_UPLOAD_ORIGIN,
+  buildEndpointUrl,
+  selectUploadOrigin
+} from './lib/EndpointUrl'
 const UPLOAD_PATH = '/sourcemap'
 
 interface UploadSingleOpts {
@@ -75,6 +79,8 @@ export async function uploadOne ({
   }, unknownArgs as Record<string, unknown>)
 
   logger.info(`Preparing upload of node source map for "${bundle}"`)
+
+  endpoint = selectUploadOrigin(apiKey, endpoint)
 
   let url
   try {
@@ -174,6 +180,8 @@ export async function uploadMultiple ({
   }, unknownArgs as Record<string, unknown>)
 
   logger.info(`Preparing upload of node source maps for "${directory}"`)
+  
+  endpoint = selectUploadOrigin(apiKey, endpoint)
 
   let url
   try {

--- a/src/uploaders/ReactNativeUploader.ts
+++ b/src/uploaders/ReactNativeUploader.ts
@@ -19,7 +19,12 @@ import {
   validateNoUnknownArgs
 } from './lib/InputValidators'
 
-import { DEFAULT_UPLOAD_ORIGIN, buildEndpointUrl } from './lib/EndpointUrl'
+import {
+  DEFAULT_UPLOAD_ORIGIN,
+  buildEndpointUrl,
+  selectUploadOrigin            
+} from './lib/EndpointUrl'
+
 const UPLOAD_PATH = '/react-native-source-map'
 
 interface CommonUploadOpts {
@@ -87,6 +92,8 @@ export async function uploadOne ({
   }, unknownArgs as Record<string, unknown>)
 
   logger.info(`Preparing upload of React Native source map (${dev ? 'dev' : 'release'} / ${platform})`)
+
+  endpoint = selectUploadOrigin(apiKey, endpoint)
 
   let url
   try {
@@ -177,6 +184,8 @@ export async function fetchAndUploadOne ({
   }, unknownArgs as Record<string, unknown>)
 
   logger.info(`Fetching React Native source map (${dev ? 'dev' : 'release'} / ${platform})`)
+
+  endpoint = selectUploadOrigin(apiKey, endpoint)
 
   let url
   try {

--- a/src/uploaders/__test__/BrowserUploader.test.ts
+++ b/src/uploaders/__test__/BrowserUploader.test.ts
@@ -822,6 +822,61 @@ test('uploadMultiple(): failure (connection error)', async () => {
   }
 })
 
+test('uploadOne(): switches to InsightHub upload origin when apiKey starts with 00000', async () => {
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  await uploadOne({
+    apiKey: '00000cafebabecafebabecafebabecafe', // Hub-style key
+    bundleUrl: 'http://mybundle.jim',
+    sourceMap: 'bundle.js.map',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/a')
+  })
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.insighthub.smartbear.com/sourcemap', // 👈 switched origin
+    expect.objectContaining({
+      apiKey: '00000cafebabecafebabecafebabecafe',
+      minifiedFile: expect.any(Object),
+      minifiedUrl: 'http://mybundle.jim',
+      overwrite: false,
+      sourceMap: expect.any(Object)
+    }),
+    {},
+    { idleTimeout: undefined }
+  )
+})
+
+test('uploadOne(): honours an explicit custom endpoint even for a Hub-style apiKey', async () => {
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  await uploadOne({
+    apiKey: '00000deadbeefdeadbeefdeadbeefdead', // Hub-style key
+    endpoint: 'https://upload.my-corp.com',      // explicit override
+    bundleUrl: 'http://mybundle.jim',
+    sourceMap: 'bundle.js.map',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/a')
+  })
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.my-corp.com/sourcemap',       // 👈 explicit origin wins
+    expect.objectContaining({
+      apiKey: '00000deadbeefdeadbeefdeadbeefdead',
+      minifiedFile: expect.any(Object),
+      minifiedUrl: 'http://mybundle.jim',
+      overwrite: false,
+      sourceMap: expect.any(Object)
+    }),
+    {},
+    { idleTimeout: undefined }
+  )
+})
+
 describe('input validation errors (when using as a JS library', () => {
   test.each([
     [ {}, 'apiKey is required and must be a string' ],

--- a/src/uploaders/__test__/NodeUploader.test.ts
+++ b/src/uploaders/__test__/NodeUploader.test.ts
@@ -629,6 +629,59 @@ test('uploadMultiple(): failure (connection error)', async () => {
   }
 })
 
+test('uploadOne(): switches to InsightHub upload origin when apiKey starts with 00000', async () => {
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  await uploadOne({
+    apiKey: '00000cafebabecafebabecafebabecafe',   // Hub-style key
+    sourceMap: 'bundle.js.map',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/a')
+  })
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.insighthub.smartbear.com/sourcemap',  
+    expect.objectContaining({
+      apiKey: '00000cafebabecafebabecafebabecafe',
+      minifiedFile: expect.any(Object),
+      minifiedUrl: 'bundle.js',
+      overwrite: false,
+      sourceMap: expect.any(Object)
+    }),
+    {},
+    { idleTimeout: undefined }
+  )
+})
+
+test('uploadOne(): honours an explicit custom endpoint even for a Hub-style apiKey', async () => {
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  await uploadOne({
+    apiKey: '00000deadbeefdeadbeefdeadbeefdead',          // Hub-style key
+    endpoint: 'https://upload.my-corp.com',                // explicit override
+    sourceMap: 'bundle.js.map',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/a')
+  })
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.my-corp.com/sourcemap',               
+    expect.objectContaining({
+      apiKey: '00000deadbeefdeadbeefdeadbeefdead',
+      minifiedFile: expect.any(Object),
+      minifiedUrl: 'bundle.js',
+      overwrite: false,
+      sourceMap: expect.any(Object)
+    }),
+    {},
+    { idleTimeout: undefined }
+  )
+})
+
 describe('input validation errors (when using as a JS library', () => {
   test.each([
     [ {}, 'apiKey is required and must be a string' ],

--- a/src/uploaders/__test__/ReactNativeUploader.test.ts
+++ b/src/uploaders/__test__/ReactNativeUploader.test.ts
@@ -1051,6 +1051,102 @@ test('fetchAndUploadOne(): Fetch mode failure to get bundle (timeout)', async ()
   }
 })
 
+test('uploadOne(): switches to InsightHub when using a Hub-style apiKey', async () => {
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  await uploadOne({
+    apiKey: '00000cafebabecafebabecafebabecafe',    // Hub key
+    platform: 'ios',
+    dev: false,
+    overwrite: true,
+    sourceMap: 'bundle.js.map',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/react-native-ios')
+  })
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.insighthub.smartbear.com/react-native-source-map', // auto-switched origin
+    expect.objectContaining({
+      apiKey: '00000cafebabecafebabecafebabecafe',
+      platform: 'ios'
+    }),
+    {},
+    { idleTimeout: undefined }
+  )
+})
+
+test('uploadOne(): explicit endpoint overrides InsightHub auto-switch', async () => {
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedRequest.mockResolvedValue()
+
+  await uploadOne({
+    apiKey: '00000deadbeefdeadbeefdeadbeefdead',   // Hub key
+    endpoint: 'https://upload.my-company.com',     // explicit override
+    platform: 'android',
+    dev: false,
+    overwrite: true,
+    sourceMap: 'bundle.js.map',
+    bundle: 'bundle.js',
+    projectRoot: path.join(__dirname, 'fixtures/react-native-android')
+  })
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest).toHaveBeenCalledWith(
+    'https://upload.my-company.com/react-native-source-map', // explicit wins
+    expect.objectContaining({
+      apiKey: '00000deadbeefdeadbeefdeadbeefdead',
+      platform: 'android'
+    }),
+    {},
+    { idleTimeout: undefined }
+  )
+})
+
+test('fetchAndUploadOne(): InsightHub origin selected automatically for Hub key', async () => {
+  const mockedFetch   = fetch   as jest.MockedFunction<typeof fetch>
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedFetch.mockResolvedValueOnce('{"version":3}') // dummy source-map
+  mockedFetch.mockResolvedValueOnce('console.log(1)') // dummy bundle
+  mockedRequest.mockResolvedValue()
+
+  await fetchAndUploadOne({
+    apiKey: '00000badd00df00d0000badd00df00d0',   // Hub key
+    platform: 'ios',
+    dev: false,
+    overwrite: true,
+    bundlerUrl: 'http://example:8081',
+    projectRoot: path.join(__dirname, 'fixtures/react-native-ios')
+  })
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest.mock.calls[0][0])
+    .toBe('https://upload.insighthub.smartbear.com/react-native-source-map')
+})
+
+test('fetchAndUploadOne(): explicit endpoint overrides InsightHub auto-switch', async () => {
+  const mockedFetch   = fetch   as jest.MockedFunction<typeof fetch>
+  const mockedRequest = request as jest.MockedFunction<typeof request>
+  mockedFetch.mockResolvedValueOnce('{"version":3}')
+  mockedFetch.mockResolvedValueOnce('console.log(1)')
+  mockedRequest.mockResolvedValue()
+
+  await fetchAndUploadOne({
+    apiKey: '00000facefeedfacefeedfacefeedface',  // Hub key
+    endpoint: 'https://upload.my-company.com',
+    platform: 'android',
+    dev: true,
+    overwrite: true,
+    bundlerUrl: 'http://example:8081',
+    projectRoot: path.join(__dirname, 'fixtures/react-native-android')
+  })
+
+  expect(mockedRequest).toHaveBeenCalledTimes(1)
+  expect(mockedRequest.mock.calls[0][0])
+    .toBe('https://upload.my-company.com/react-native-source-map')
+})
+
 describe('input validation errors (when using as a JS library', () => {
   test.each([
     [ {}, 'apiKey is required and must be a string' ],

--- a/src/uploaders/lib/EndpointUrl.ts
+++ b/src/uploaders/lib/EndpointUrl.ts
@@ -1,12 +1,24 @@
 export const DEFAULT_UPLOAD_ORIGIN = 'https://upload.bugsnag.com'
 
+/** Hub keys start with five 0s */
+export const HUB_PREFIX        = '00000'
+export const HUB_UPLOAD_ORIGIN = 'https://upload.insighthub.smartbear.com'
+
+/**
+ * If the caller hasn’t specified a custom --endpoint and the apiKey looks like
+ * an InsightHub key, silently flip the origin to the Hub uploader.
+ */
+export function selectUploadOrigin (apiKey: string,
+                                    endpoint: string | undefined): string {
+  if ((endpoint === undefined || endpoint === DEFAULT_UPLOAD_ORIGIN) &&
+      apiKey.startsWith(HUB_PREFIX)) {
+    return HUB_UPLOAD_ORIGIN
+  }
+  return endpoint ?? DEFAULT_UPLOAD_ORIGIN
+}
+
 export function buildEndpointUrl (origin: string, path: string): string {
   const url = new URL(origin)
-  
-  // if no path was given use the default
-  if (url.pathname === '/') {
-    url.pathname = path
-  }
-
+  if (url.pathname === '/') { url.pathname = path }
   return url.toString()
 }


### PR DESCRIPTION
## Goal

Set default endpoints based on API key. If no endpoint is configured, payloads should be sent to `*.insighthub.smartbear.com` if the API key starts with `00000`.

## Testing

Aded Unit Tests